### PR TITLE
Produce step .d file for indexbuild

### DIFF
--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -47,10 +47,6 @@ public class XCPostbuild {
             exit(1, "FATAL: Postbuild initialization failed with error: \(error)")
         }
 
-        guard context.action != .index else {
-            printToUser("Indexbuild. Skip remote cache")
-            exit(0)
-        }
 
         // Postbuild cannot disable marker, so NoopMarkerWriter used instead of a real file writer
         let modeController = PhaseCacheModeController(
@@ -65,6 +61,15 @@ public class XCPostbuild {
             fileManager: fileManager
         )
 
+        guard context.action != .index else {
+            do {
+                try modeController.disable()
+                infoLog("Indexbuild. Skip remote cache")
+            } catch {
+                exit(1, "FATAL: Postbuild finishing failed with error: \(error)")
+            }
+            exit(0)
+        }
 
         do {
             // Initialize dependencies

--- a/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
@@ -20,6 +20,11 @@
 import Foundation
 
 public class XCPrebuild {
+    private enum DisabledRCMessage {
+        case error(message: String)
+        case info(message: String)
+    }
+
     public init() {}
 
     // swiftlint:disable:next function_body_length
@@ -34,11 +39,6 @@ public class XCPrebuild {
         } catch {
             // Fatal error:
             exit(1, "FATAL: Prebuild initialization failed with error: \(error)")
-        }
-
-        guard context.action != .index else {
-            printToUser("Indexbuild. Skip remote cache")
-            exit(0)
         }
 
         // Xcode may call xcprebuild phase even none of compilation files has changed (e.g. when switching between
@@ -62,12 +62,21 @@ public class XCPrebuild {
             fileManager: fileManager
         )
 
+        guard context.action != .index else {
+            // Always fallback to local build for a build used for indexing
+            disableRemoteCache(
+                modeController: modeController,
+                message: .info(message: "Prebuild step disabled, indexbuild mode discovered")
+            )
+            exit(0)
+        }
+
         guard config.mode != .producer else {
             // Prebuild phase for a producer is noop
             // TODO: Consider a note to not adding that prebuildstep to the Xcode target
             disableRemoteCache(
                 modeController: modeController,
-                errorMessage: "Prebuild step disabled, selected mode: \(config.mode)"
+                message: .error(message: "Prebuild step disabled, selected mode: \(config.mode)")
             )
             exit(0)
         }
@@ -77,7 +86,7 @@ public class XCPrebuild {
             // Short-circut early all `xc*` apps until remote commit change
             disableRemoteCache(
                 modeController: modeController,
-                errorMessage: "Prebuild step was disabled for current commit: \(context.remoteCommit)"
+                message: .error(message: "Prebuild step was disabled for current commit: \(context.remoteCommit)")
             )
             exit(0)
         }
@@ -177,15 +186,21 @@ public class XCPrebuild {
         } catch {
             disableRemoteCache(
                 modeController: modeController,
-                errorMessage: "Prebuild step failed with error: \(error)"
+                message: .error(message: "Prebuild step failed with error: \(error)")
             )
         }
     }
 
-    private func disableRemoteCache(modeController: PhaseCacheModeController, errorMessage: String?) {
-        if let message = errorMessage {
-            errorLog(message)
+    private func disableRemoteCache(modeController: PhaseCacheModeController, message: DisabledRCMessage?) {
+        switch message {
+        case .error(message: let errorMessage):
+            errorLog(errorMessage)
+        case .info(message: let infoMessage):
+            infoLog(infoMessage)
+        default:
+            break
         }
+
         do {
             try modeController.disable()
         } catch {


### PR DESCRIPTION
When Xcode calls `indexbuild` action, we should create a valid .d (make-style dependency file), otherwise Xcode fails a build with an error like:
```
unable to open dependencies file ({redacted}/Index/Build/Intermediates.noindex/{redacted}.build/prebuild.d)
Command PhaseScriptExecution emitted errors but did not return a nonzero exit code to indicate failure
```

This PR asks `modeController`s to disable a cache, which is a legal way to disable the remote cache flow and fallback other wrappers (like `xcswiftc`, `xccc` etc.) to the local build.

Minor: do not print the output to the user, just logging a message that is stored in system logs.