### PR TITLE
Release CocoaPods plugin 0.0.2

### DIFF
--- a/cocoapods-plugin/README.md
+++ b/cocoapods-plugin/README.md
@@ -4,6 +4,14 @@ The CocoaPods plugin that integrates XCRemoteCache with the project.
 
 ## Installation
 
+### Using RubyGems
+
+```bash
+gem install cocoapods-xcremotecache
+```
+
+### From sources
+
 Build & install the plugin
 
 ```bash

--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module CocoapodsXcremotecache
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
Releasing cocoapods-xcremotecache plugin with 0.0.2: https://rubygems.org/gems/cocoapods-xcremotecache/versions/0.0.2