### PR TITLE
[CocoaPodsPlugin] Support first-party caching for incremental install

### DIFF
--- a/cocoapods-plugin/README.md
+++ b/cocoapods-plugin/README.md
@@ -60,3 +60,7 @@ To fully uninstall the plugin, call:
 ```bash
 gem uninstall cocoapods-xcremotecache
 ```
+
+## Limitations
+
+* When `generate_multiple_pod_projects` mode is enabled, only first-party targets are cached by XCRemoteCache (all dependencies are compiled locally).

--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
@@ -350,7 +350,7 @@ module CocoapodsXCRemoteCacheModifier
 
           # Prepare XCRC
 
-          # Pods projects can be generated only once (if incremental_installation is abled)
+          # Pods projects can be generated only once (if incremental_installation is enabled)
           # Always integrate XCRemoteCache to all Pods, in case it will be needed later
           unless installer_context.pods_project.nil?
             # Attach XCRemoteCache to Pods targets

--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module CocoapodsXcremotecache
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
When `Podfile` has enabled incremental_installation, e.g. 
```
install! 'cocoapods',
         :generate_multiple_pod_projects => true
         :incremental_installation => true
```
CocoaPods plugin was failing as `pods_project` is `nil` (see [here](https://github.com/CocoaPods/CocoaPods/issues/8604#issuecomment-472075100)). To fix that, this PR optimistically integrates XCRemoteCache to all targets in the `Pods` project (adding pre/postbuild scripts,`CC`, `SWIFT_EXEC` etc) on a first `Pods` project generation as the plugin will not have a chance to integrate/deintegrate it in consecutive invocations (cocoapods intentionally leaves `Pods` project intact to not generate it without need). 
There will be just a tiny performance penalty if no artifacts are ready and XCRemoteCache is disabled - xcprebuild will quit early when a global `.rc/arc.rc` doesn't exist and fallback to the local compilation.

By the way, I revealed that `generate_multiple_pod_projects` mode is not fully supported (for now). Such setup changes a way the `Pods` project is configured and each pod has a separate .xcodeproj.
To support it, manually modifying each .xcodeproj to integrate XCRemoteCache (build steps build settings etc.), would be required, but so far CocoaPods Plugins interface does not provide a nice API for that ([link](https://rubydoc.info/gems/cocoapods/Pod/Installer/PostInstallHooksContext)).

#### Standard
<img width="270" alt="Screenshot 2021-11-21 at 19 18 52" src="https://user-images.githubusercontent.com/9629417/142774132-5d0b15b0-9516-4d19-9389-efadac127016.png">


#### generate_multiple_pod_projects
<img width="234" alt="Screenshot 2021-11-21 at 19 17 39" src="https://user-images.githubusercontent.com/9629417/142774118-c94fcb16-2a78-4f7c-bda6-dc87b8b18a6b.png">


Fixes #18