### PR TITLE
Fix SwiftLint warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,7 @@ disabled_rules:
   - superfluous_disable_command # Disabled since we disable some rules pre-emptively to avoid issues in the future
   - todo                        # Temporarily disabled. We have too many right now hiding real issues :(
   - nesting                     # Does not make sense anymore since Swift 4 uses nested `CodingKeys` enums for example
+  - trailing_dot_in_comments    # Triggers warnings for generated file headers
 
 opt_in_rules:
   - anyobject_protocol

--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ task :lint => [:prepare] do
   puts 'Run linting'
 
   system("swiftformat --lint --config .swiftformat --cache ignore .") or abort "swiftformat failure" if SWIFTFORMAT_ENABLED
-  system("swiftlint lint --config .swiftlint.yml") or abort "swiftlint failure" if SWIFTLINT_ENABLED
+  system("swiftlint lint --config .swiftlint.yml --strict") or abort "swiftlint failure" if SWIFTLINT_ENABLED
 end
 
 task :autocorrect => [:prepare]  do 

--- a/Sources/XCRemoteCache/Commands/Plugins/Thinning/ThinningDiskSwiftcProductsGenerator.swift
+++ b/Sources/XCRemoteCache/Commands/Plugins/Thinning/ThinningDiskSwiftcProductsGenerator.swift
@@ -40,7 +40,7 @@ class ThinningDiskSwiftcProductsGenerator: SwiftcProductsGenerator {
         destinationSwiftmodulePaths = Dictionary(
             uniqueKeysWithValues: SwiftmoduleFileExtension.SwiftmoduleExtensions
                 .map { ext, _ in
-                    switch (ext) {
+                    switch ext {
                     case .swiftsourceinfo:
                         let dest = modulePathDir.appendingPathComponent("Project")
                             .appendingPathComponent(moduleName)

--- a/Sources/XCRemoteCache/Commands/Prebuild/Prebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/Prebuild.swift
@@ -55,6 +55,7 @@ class Prebuild {
         self.artifactConsumerPrebuildPlugins = artifactConsumerPrebuildPlugins
     }
 
+    // swiftlint:disable:next function_body_length
     public func perform() throws -> PrebuildResult {
         guard case .available(let commit) = context.remoteCommit else {
             return .incompatible

--- a/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
@@ -129,7 +129,10 @@ public class XCPrebuild {
                 algorithm: MD5Algorithm()
             )
             let organizer = ZipArtifactOrganizer(targetTempDir: context.targetTempDir, fileManager: fileManager)
-            let compilationHistoryOrganizer = CompilationHistoryFileOrganizer(context.compilationHistoryFile, fileManager: fileManager)
+            let compilationHistoryOrganizer = CompilationHistoryFileOrganizer(
+                context.compilationHistoryFile,
+                fileManager: fileManager
+            )
             let metaReader = JsonMetaReader(fileAccessor: fileManager)
             var consumerPlugins: [ArtifactConsumerPrebuildPlugin] = []
 

--- a/Sources/XCRemoteCache/Commands/Prepare/CCWrapperBuilder.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/CCWrapperBuilder.swift
@@ -79,6 +79,7 @@ class TemplateBasedCCWrapperBuilder: CCWrapperBuilder {
 
 
     /// Generates source of the cc wrapper
+    // swiftlint:disable line_length
     // swiftlint:disable:next function_body_length
     private func buildWrapperSource(clangCommand: String, markerFilename: String, commitSha: String) -> String {
         return """
@@ -516,5 +517,5 @@ class TemplateBasedCCWrapperBuilder: CCWrapperBuilder {
            #pragma GCC diagnostic pop
         }
         """
-    } // swiftlint:disable:next file_length
-}
+    } // swiftlint:disable:next file_length line_length
+} // swiftlint:enable line_length

--- a/Sources/XCRemoteCache/Commands/Prepare/Integrate/LLDBInitPatcher.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/Integrate/LLDBInitPatcher.swift
@@ -56,7 +56,7 @@ class FileLLDBInitPatcher: LLDBInitPatcher {
     }
 
     private func findIndices(in collection: [String], value: String) -> [Int] {
-        collection.enumerated().reduce([]) { (result, line) -> [Int] in
+        collection.enumerated().reduce([]) { result, line -> [Int] in
             if line.element == Self.preambleString {
                 return result + [line.offset]
             }
@@ -75,7 +75,7 @@ class FileLLDBInitPatcher: LLDBInitPatcher {
             var contentLines = originalContentLines
             let preambleIndices = findIndices(in: contentLines, value: Self.preambleString)
 
-            if preambleIndices.count > 0 {
+            if !preambleIndices.isEmpty {
                 let firstLLDBCommandIndex = preambleIndices[0] + 1
                 if firstLLDBCommandIndex >= contentLines.count {
                     // corrupted file, append the script line at the bottom

--- a/Sources/XCRemoteCache/Commands/Prepare/Integrate/XCIntegrate.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/Integrate/XCIntegrate.swift
@@ -64,6 +64,7 @@ public class XCIntegrate {
         self.output = output
     }
 
+    // swiftlint:disable:next function_body_length
     public func main() {
         do {
             let env = ProcessInfo.processInfo.environment
@@ -114,7 +115,7 @@ public class XCIntegrate {
 
             let integrator = XcodeProjIntegrate(
                 project: context.projectPath,
-                mode:context.mode,
+                mode: context.mode,
                 binaries: context.binaries,
                 configurationIncludeOracle: configurationOracle,
                 targetIncludeOracle: targetOracle,

--- a/Sources/XCRemoteCache/Commands/Prepare/Integrate/XcodeProjIntegrate.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/Integrate/XcodeProjIntegrate.swift
@@ -114,7 +114,9 @@ struct XcodeProjIntegrate: Integrate {
         markPhase = PBXShellScriptBuildPhase(
             name: "\(Self.BuildStepPrefix)RemoteCache_mark",
             inputPaths: [binaries.prepare.path],
-            shellScript: "\"$SCRIPT_INPUT_FILE_0\" mark --configuration \"$CONFIGURATION\" --platform \"$PLATFORM_NAME\""
+            shellScript:
+                "\"$SCRIPT_INPUT_FILE_0\" mark " +
+                "--configuration \"$CONFIGURATION\" --platform \"$PLATFORM_NAME\""
         )
     }
 
@@ -129,6 +131,7 @@ struct XcodeProjIntegrate: Integrate {
         try encodedYAML.write(to: configOverrideLocation, atomically: false, encoding: .utf8)
     }
 
+    // swiftlint:disable:next function_body_length
     func run() throws {
         let outputFile = output ?? projectURL
         let projectRoot = projectURL.deletingLastPathComponent()

--- a/Sources/XCRemoteCache/Commands/Prepare/Integrate/XcodeSettingsFlags.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/Integrate/XcodeSettingsFlags.swift
@@ -100,7 +100,7 @@ struct XcodeSettingsCFlags: XcodeSettingsFlags {
         case (.some(let existing), _):
             var flagsComponents: [String] = existing.split(separator: " ").map(String.init)
             // remove (if exists)
-            let existingFlagIndex = flagsComponents.firstIndex { (component) -> Bool in
+            let existingFlagIndex = flagsComponents.firstIndex { component -> Bool in
                 component.hasPrefix("\(Self.prefix)\(key)=")
             }
             if let index = existingFlagIndex {

--- a/Sources/XCRemoteCache/Commands/Prepare/XCPrepareMark.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/XCPrepareMark.swift
@@ -38,6 +38,7 @@ public class XCPrepareMark {
         self.commit = commit
     }
 
+    // swiftlint:disable:next function_body_length
     public func main() {
         let env = ProcessInfo.processInfo.environment
         let fileManager = FileManager.default

--- a/Sources/XCRemoteCache/Commands/Swiftc/XCSwiftc.swift
+++ b/Sources/XCRemoteCache/Commands/Swiftc/XCSwiftc.swift
@@ -101,7 +101,10 @@ public class XCSwiftc {
             objcHeaderOutput: context.objcHeaderOutput,
             diskCopier: HardLinkDiskCopier(fileManager: fileManager)
         )
-        let allInvocationsStorage = ExistingFileStorage(storageFile: context.invocationHistoryFile, command: swiftcCommand)
+        let allInvocationsStorage = ExistingFileStorage(
+            storageFile: context.invocationHistoryFile,
+            command: swiftcCommand
+        )
         // When fallbacking to local compilation do not call historical `swiftc` invocations
         // The current fallback invocation already compiles all files in a target
         let invocationStorage = FilteredInvocationStorage(

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -94,10 +94,11 @@ public struct XCRemoteCacheConfig: Encodable {
     var focusedTargets: [String] = []
     ///  Disable cache for http requests to fecth metadata and download artifacts
     var disableHttpCache: Bool = false
-    /// Path, relative to $TARGET_TEMP_DIR which gathers all compilation commands that should be executed if a target
-    /// switches to local compilation. Example: A new `.swift` file invalidates remote artifact and triggers local compilation
-    /// When that happens, all previously skipped clang build steps need to be eventually called locally - this file lists
-    /// all these commands.
+    /// Path, relative to $TARGET_TEMP_DIR which gathers all compilation commands that should be e
+    /// xecuted if a target switches to local compilation.
+    /// Example: A new `.swift` file invalidates remote arXcodeProjIntegrate.swifttifact and triggers local compilation
+    /// When that happens, all previously skipped clang build steps
+    /// need to be eventually called locally - this file lists all these commands.
     var compilationHistoryFile: String = "history.compile"
     /// Timeout for remote response data interval (in seconds). If an interval between data chunks is
     /// longer than a timeout, a request fails
@@ -124,6 +125,7 @@ public struct XCRemoteCacheConfig: Encodable {
 extension XCRemoteCacheConfig {
     /// Merges existing config with the other config and returns a final result
     /// `other` scheme overrides existing configuration
+    // swiftlint:disable:next function_body_length
     func merged(with scheme: ConfigFileScheme) -> XCRemoteCacheConfig {
         var merge = self
         merge.mode = scheme.mode ?? mode

--- a/Sources/XCRemoteCache/Network/Authentication/AWSV4Signature.swift
+++ b/Sources/XCRemoteCache/Network/Authentication/AWSV4Signature.swift
@@ -35,9 +35,22 @@ struct AWSV4Signature {
         request.setValue((request.httpBody ?? Data()).sha256(), forHTTPHeaderField: "x-amz-content-sha256")
 
         let canonicalRequest = CanonicalRequest(request: request)
-        let stringToSign = StringToSign(region: region, service: service, canonicalRequestHash: canonicalRequest.hash, date: date)
-        let awsV4SigningKey = AWSV4SigningKey(secretAccessKey: secretKey, region: region, service: service, date: date)
-        let signature = HMAC.calcHMAC(keyArray: awsV4SigningKey.value, value: stringToSign.value).map { String(format: "%02hhx", $0) }.joined()
+        let stringToSign = StringToSign(
+            region: region,
+            service: service,
+            canonicalRequestHash: canonicalRequest.hash,
+            date: date
+        )
+        let awsV4SigningKey = AWSV4SigningKey(
+            secretAccessKey: secretKey,
+            region: region,
+            service: service,
+            date: date
+        )
+        let signature = HMAC.calcHMAC(
+            keyArray: awsV4SigningKey.value,
+            value: stringToSign.value
+        ).map { String(format: "%02hhx", $0) }.joined()
 
         let authValue =
             "AWS4-HMAC-SHA256 " +

--- a/Sources/XCRemoteCache/Network/Authentication/HMAC.swift
+++ b/Sources/XCRemoteCache/Network/Authentication/HMAC.swift
@@ -52,7 +52,14 @@ struct HMAC {
 
     private static func calcHMAC(keyUnsafeBytes: UnsafeRawBufferPointer, value: String, out: UnsafeMutableRawPointer!) {
         value.data(using: .utf8)!.withUnsafeBytes { value in
-            CCHmac(CCHmacAlgorithm(kCCHmacAlgSHA256), keyUnsafeBytes.baseAddress, Int(keyUnsafeBytes.count), value.baseAddress, Int(value.count), out)
+            CCHmac(
+                CCHmacAlgorithm(kCCHmacAlgSHA256),
+                keyUnsafeBytes.baseAddress,
+                Int(keyUnsafeBytes.count),
+                value.baseAddress,
+                Int(value.count),
+                out
+            )
         }
     }
 }

--- a/Sources/XCRemoteCache/Stats/CacheHitLogger.swift
+++ b/Sources/XCRemoteCache/Stats/CacheHitLogger.swift
@@ -28,8 +28,8 @@ protocol CacheHitLogger {
 /// Logs target hit or miss, based on an action of a build
 class ActionSpecificCacheHitLogger: CacheHitLogger {
     private let statsLogger: StatsLogger
-    private let hitCounter: XCRemoteCacheStatistics.Counter
-    private let missCounter: XCRemoteCacheStatistics.Counter
+    private let hitCounter: XCRemoteCacheStatistics.Counter?
+    private let missCounter: XCRemoteCacheStatistics.Counter?
 
     init(action: BuildActionType, statsLogger: StatsLogger) {
         self.statsLogger = statsLogger
@@ -37,19 +37,24 @@ class ActionSpecificCacheHitLogger: CacheHitLogger {
         case .index:
             hitCounter = .indexingTargetHitCount
             missCounter = .indexingTargetMissCount
-        case .unknown:
-            fallthrough
         case .build:
             hitCounter = .targetCacheHit
             missCounter = .targetCacheMiss
+        case .unknown:
+            hitCounter = nil
+            missCounter = nil
         }
     }
 
     func logHit() throws {
-        try statsLogger.log(hitCounter)
+        if let hitCounter = hitCounter {
+            try statsLogger.log(hitCounter)
+        }
     }
 
     func logMiss() throws {
-        try statsLogger.log(missCounter)
+        if let missCounter = missCounter {
+            try statsLogger.log(missCounter)
+        }
     }
 }

--- a/Tests/XCRemoteCacheTests/Artifacts/ArtifactSwiftProductsBuilderImplTests.swift
+++ b/Tests/XCRemoteCacheTests/Artifacts/ArtifactSwiftProductsBuilderImplTests.swift
@@ -31,6 +31,7 @@ class ArtifactSwiftProductsBuilderImplTests: FileXCTestCase {
     private var builder: ArtifactSwiftProductsBuilderImpl!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         let rootDir = try prepareTempDir()
         moduleDir = rootDir.appendingPathComponent("Products")
         swiftmoduleFile = moduleDir.appendingPathComponent("MyModule.swiftmodule")
@@ -47,24 +48,41 @@ class ArtifactSwiftProductsBuilderImplTests: FileXCTestCase {
     func testIncludesRequiredSwiftmoduleFiles() throws {
         try fileManager.spt_createFile(swiftmoduleFile, content: "swiftmodule")
         try fileManager.spt_createFile(swiftmoduleDocFile, content: "swiftdoc")
-        let builderSwiftmoduleDir = builder.buildingArtifactSwiftModulesLocation().appendingPathComponent("arm64")
-        let expectedBuildedSwiftmoduleFile = builderSwiftmoduleDir.appendingPathComponent("MyModule.swiftmodule")
-        let expectedBuildedSwiftmoduledocFile = builderSwiftmoduleDir.appendingPathComponent("MyModule.swiftdoc")
+        let builderSwiftmoduleDir =
+            builder
+                .buildingArtifactSwiftModulesLocation()
+                .appendingPathComponent("arm64")
+        let expectedBuildedSwiftmoduleFile =
+            builderSwiftmoduleDir.appendingPathComponent("MyModule.swiftmodule")
+        let expectedBuildedSwiftmoduledocFile =
+            builderSwiftmoduleDir.appendingPathComponent("MyModule.swiftdoc")
 
         try builder.includeModuleDefinitionsToTheArtifact(arch: "arm64", moduleURL: swiftmoduleFile)
 
-        XCTAssertEqual(fileManager.contents(atPath: expectedBuildedSwiftmoduleFile.path), "swiftmodule".data(using: .utf8))
-        XCTAssertEqual(fileManager.contents(atPath: expectedBuildedSwiftmoduledocFile.path), "swiftdoc".data(using: .utf8))
+        XCTAssertEqual(
+            fileManager.contents(atPath: expectedBuildedSwiftmoduleFile.path),
+            "swiftmodule".data(using: .utf8)
+        )
+        XCTAssertEqual(
+            fileManager.contents(atPath: expectedBuildedSwiftmoduledocFile.path),
+            "swiftdoc".data(using: .utf8)
+        )
     }
 
     func testIncludesAllSwiftmoduleFiles() throws {
         try fileManager.spt_createEmptyFile(swiftmoduleFile)
         try fileManager.spt_createEmptyFile(swiftmoduleDocFile)
         try fileManager.spt_createEmptyFile(swiftmoduleSourceInfoFile)
-        let builderSwiftmoduleDir = builder.buildingArtifactSwiftModulesLocation().appendingPathComponent("arm64")
-        let expectedBuildedSwiftmoduleFile = builderSwiftmoduleDir.appendingPathComponent("MyModule.swiftmodule")
-        let expectedBuildedSwiftmoduledocFile = builderSwiftmoduleDir.appendingPathComponent("MyModule.swiftdoc")
-        let expectedBuildedSwiftSourceInfoFile = builderSwiftmoduleDir.appendingPathComponent("MyModule.swiftsourceinfo")
+        let builderSwiftmoduleDir =
+            builder
+                .buildingArtifactSwiftModulesLocation()
+                .appendingPathComponent("arm64")
+        let expectedBuildedSwiftmoduleFile =
+            builderSwiftmoduleDir.appendingPathComponent("MyModule.swiftmodule")
+        let expectedBuildedSwiftmoduledocFile =
+            builderSwiftmoduleDir.appendingPathComponent("MyModule.swiftdoc")
+        let expectedBuildedSwiftSourceInfoFile =
+            builderSwiftmoduleDir.appendingPathComponent("MyModule.swiftsourceinfo")
 
         try builder.includeModuleDefinitionsToTheArtifact(arch: "arm64", moduleURL: swiftmoduleFile)
 
@@ -74,6 +92,11 @@ class ArtifactSwiftProductsBuilderImplTests: FileXCTestCase {
     }
 
     func testFailsIncludingWhenMissingRequiredSwiftmoduleFiles() throws {
-        XCTAssertThrowsError(try builder.includeModuleDefinitionsToTheArtifact(arch: "arm64", moduleURL: swiftmoduleFile))
+        XCTAssertThrowsError(
+            try builder.includeModuleDefinitionsToTheArtifact(
+                arch: "arm64",
+                moduleURL: swiftmoduleFile
+            )
+        )
     }
 }

--- a/Tests/XCRemoteCacheTests/Commands/Prepare/Integrate/FileLLDBInitPatcherTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/Prepare/Integrate/FileLLDBInitPatcherTests.swift
@@ -28,6 +28,7 @@ class FileLLDBInitPatcherTests: XCTestCase {
     private var patcher: FileLLDBInitPatcher!
 
     override func setUp() {
+        super.setUp()
         accessor = FileAccessorFake(mode: .normal)
         patcher = FileLLDBInitPatcher(
             file: lldbInitPath,

--- a/Tests/XCRemoteCacheTests/Commands/SwiftcFilemapInputEditorTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/SwiftcFilemapInputEditorTests.swift
@@ -21,8 +21,8 @@
 import XCTest
 
 class SwiftcFilemapInputEditorTests: FileXCTestCase {
-
-    private let sampleInfo = SwiftCompilationInfo(info: SwiftModuleCompilationInfo(
+    private let sampleInfo = SwiftCompilationInfo(
+        info: SwiftModuleCompilationInfo(
         dependencies: nil,
         swiftDependencies: "/"
     ), files: [])
@@ -65,17 +65,19 @@ class SwiftcFilemapInputEditorTests: FileXCTestCase {
            }
         }
         """#.data(using: .utf8)!
-        let expectedInfo = SwiftCompilationInfo(info: SwiftModuleCompilationInfo(
-            dependencies: "/master.d",
-            swiftDependencies: "/master.swiftdeps"
-        ), files: [
-            SwiftFileCompilationInfo(
-                file: "/file1.swift",
-                dependencies: "/file1.d",
-                object: "/file1.o",
-                swiftDependencies: "/file1.swiftdeps"
+        let expectedInfo = SwiftCompilationInfo(
+            info: SwiftModuleCompilationInfo(
+                dependencies: "/master.d",
+                swiftDependencies: "/master.swiftdeps"
             ),
-        ])
+            files: [
+                SwiftFileCompilationInfo(
+                    file: "/file1.swift",
+                    dependencies: "/file1.d",
+                    object: "/file1.o",
+                    swiftDependencies: "/file1.swiftdeps"
+                ),
+            ])
         try fileManager.spt_writeToFile(atPath: inputFile.path, contents: infoContentData)
 
         let readInfo = try editor.read()
@@ -93,17 +95,18 @@ class SwiftcFilemapInputEditorTests: FileXCTestCase {
     }
 
     func testWritingSavesContentWithOptionalParameters() throws {
-        let extendedInfo = SwiftCompilationInfo(info: SwiftModuleCompilationInfo(
-            dependencies: "/master.d",
-            swiftDependencies: "/master.swiftdeps"
-        ), files: [
-            SwiftFileCompilationInfo(
-                file: "/file1.swift",
-                dependencies: "/file1.d",
-                object: "/file1.o",
-                swiftDependencies: "/file1.swiftdeps"
-            ),
-        ])
+        let extendedInfo = SwiftCompilationInfo(
+            info: SwiftModuleCompilationInfo(
+                dependencies: "/master.d",
+                swiftDependencies: "/master.swiftdeps"
+            ), files: [
+                SwiftFileCompilationInfo(
+                    file: "/file1.swift",
+                    dependencies: "/file1.d",
+                    object: "/file1.o",
+                    swiftDependencies: "/file1.swiftdeps"
+                ),
+            ])
 
         try editor.write(extendedInfo)
 

--- a/Tests/XCRemoteCacheTests/Commands/SwiftcTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/SwiftcTests.swift
@@ -277,7 +277,9 @@ class SwiftcTests: FileXCTestCase {
         let artifactObjCHeader = URL(fileURLWithPath: "/cachedArtifact/include/archTest/Target-Swift.h")
         let artifactSwiftmodule = URL(fileURLWithPath: "/cachedArtifact/swiftmodule/archTest/Target.swiftmodule")
         let artifactSwiftdoc = URL(fileURLWithPath: "/cachedArtifact/swiftmodule/archTest/Target.swiftdoc")
-        let artifactSwiftSourceInfo = URL(fileURLWithPath: "/cachedArtifact/swiftmodule/archTest/Target.swiftsourceinfo")
+        let artifactSwiftSourceInfo = URL(
+            fileURLWithPath: "/cachedArtifact/swiftmodule/archTest/Target.swiftsourceinfo"
+        )
 
         artifactOrganizer = ArtifactOrganizerFake(artifactRoot: artifactRoot)
         let swiftc = Swiftc(
@@ -457,5 +459,5 @@ class SwiftcTests: FileXCTestCase {
         )
 
         XCTAssertNoThrow(try swiftc.mockCompilation())
-    }
+    } // swiftlint:disable:next file_length
 }

--- a/Tests/XCRemoteCacheTests/Dependencies/FileFingerprintSyncerTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/FileFingerprintSyncerTests.swift
@@ -27,6 +27,7 @@ class FileFingerprintSyncerTests: FileXCTestCase {
     private var swiftmoduleDir: URL!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         syncer = FileFingerprintSyncer(
             fingerprintOverrideExtension: "md5",
             dirAccessor: fileManager,

--- a/Tests/XCRemoteCacheTests/Dependencies/TargetDependenciesReaderTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/TargetDependenciesReaderTests.swift
@@ -27,6 +27,7 @@ class TargetDependenciesReaderTests: XCTestCase {
     private var reader: TargetDependenciesReader!
 
     override func setUp() {
+        super.setUp()
         dirAccessor = DirAccessorFake()
         /// A Factory that builds a faked dependency reader that returns a single dependency,
         /// a basename of the input .d file and the ".swift" extension

--- a/Tests/XCRemoteCacheTests/FileAccess/Copier/CopyDiskCopierTests.swift
+++ b/Tests/XCRemoteCacheTests/FileAccess/Copier/CopyDiskCopierTests.swift
@@ -27,6 +27,7 @@ class CopyDiskCopierTests: FileXCTestCase {
     private var emptySourceFile: URL!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         workingDir = try prepareTempDir()
         emptySourceFile = workingDir.appendingPathComponent("source")
         try fileManager.spt_writeToFile(atPath: emptySourceFile.path, contents: Data())

--- a/Tests/XCRemoteCacheTests/Output/FilteredInvocationStorageTests.swift
+++ b/Tests/XCRemoteCacheTests/Output/FilteredInvocationStorageTests.swift
@@ -26,6 +26,7 @@ class FilteredInvocationStorageTests: XCTestCase {
     var storage: FilteredInvocationStorage!
 
     override func setUp() {
+        super.setUp()
         storage = FilteredInvocationStorage(storage: underlyingStorage, retrieveIgnoredCommands: ["to_ignore"])
     }
 

--- a/Tests/XCRemoteCacheTests/Output/InvocationFileStorageTests.swift
+++ b/Tests/XCRemoteCacheTests/Output/InvocationFileStorageTests.swift
@@ -28,6 +28,7 @@ class InvocationFileStorageTests: FileXCTestCase {
     private var storage: ExistingFileStorage!
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         file = try prepareTempDir().appendingPathComponent("file.history")
         try fileManager.spt_createEmptyFile(file)
         storage = ExistingFileStorage(storageFile: file, command: command)

--- a/Tests/XCRemoteCacheTests/Stats/ActionSpecificCacheHitLoggerTests.swift
+++ b/Tests/XCRemoteCacheTests/Stats/ActionSpecificCacheHitLoggerTests.swift
@@ -25,6 +25,7 @@ class ActionSpecificCacheHitLoggerTests: FileXCTestCase {
     private var coordinator: StatsCoordinator!
 
     override func setUp() {
+        super.setUp()
         coordinator = InMemoryStatsCoordinator()
     }
 


### PR DESCRIPTION
Fixed SwiftLint warnings and enabled strict linting in `Rakefile`
Had to disable `trailing_dot_in_comments` since it would account for the most warnings