### PR TITLE
Add producer-fast mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ xcremotecache/xcprepare integrate --input <yourProject.xcodeproj> --mode consume
 | Argument | Description | Default | Required |
 | ------------- | ------------- | ------------- | ------------- |
 | `--input` | .xcodeproj location  | N/A | ✅ |
-| `--mode` | mode. Supported values: `consumer`, `producer` | N/A | ✅ |
+| `--mode` | mode. Supported values: `consumer`, `producer`, `producer-fast`(experimental) | N/A | ✅ |
 | `--targets-include` | comma-separated list of targets to integrate XCRemoteCache. | `""` | ⬜️ |
 | `--targets-exclude` | comma-separated list of targets to not integrate XCRemoteCache. Takes priority over --targets-include.  | `""` | ⬜️ |
 | `--configurations-include` | comma-separated list of configurations to integrate XCRemoteCache.  | `""` | ⬜️ |

--- a/Sources/XCRemoteCache/Artifacts/ArtifactCreator.swift
+++ b/Sources/XCRemoteCache/Artifacts/ArtifactCreator.swift
@@ -41,6 +41,7 @@ class BuildArtifactCreator: ArtifactSwiftProductsBuilderImpl, ArtifactCreator {
     private let moduleName: String?
     private let modulesFolderPath: String
     private let dSYMPath: URL
+    private let metaWriter: MetaWriter
     private let fileManager: FileManager
 
     init(
@@ -50,6 +51,7 @@ class BuildArtifactCreator: ArtifactSwiftProductsBuilderImpl, ArtifactCreator {
         moduleName: String?,
         modulesFolderPath: String,
         dSYMPath: URL,
+        metaWriter: MetaWriter,
         fileManager: FileManager
     ) {
         self.buildDir = buildDir
@@ -59,6 +61,7 @@ class BuildArtifactCreator: ArtifactSwiftProductsBuilderImpl, ArtifactCreator {
         self.moduleName = moduleName
         self.fileManager = fileManager
         self.dSYMPath = dSYMPath
+        self.metaWriter = metaWriter
         super.init(workingDir: tempDir, moduleName: moduleName, fileManager: fileManager)
     }
 
@@ -72,7 +75,11 @@ class BuildArtifactCreator: ArtifactSwiftProductsBuilderImpl, ArtifactCreator {
         let dynamicLibraryArtifacts = try prepareDynamicLibraryArtifacts()
         zipPaths.append(contentsOf: dynamicLibraryArtifacts)
 
-        let creator = ZipArtifactCreator(workingDir: zipWorkingDir, fileManager: fileManager)
+        let creator = ZipArtifactCreator(
+            workingDir: zipWorkingDir,
+            metaWriter: metaWriter,
+            fileManager: fileManager
+        )
         return try creator.createArtifact(zipContent: zipPaths, artifactKey: artifactKey, meta: meta)
     }
 

--- a/Sources/XCRemoteCache/Artifacts/ZipArtifactCreator.swift
+++ b/Sources/XCRemoteCache/Artifacts/ZipArtifactCreator.swift
@@ -23,11 +23,12 @@ import Zip
 class ZipArtifactCreator {
     /// Location where zip file should be generated
     private let workingDir: URL
+    private let metaWriter: MetaWriter
     private let fileManager: FileManager
-    private let metaEncoder = JSONEncoder()
 
-    init(workingDir: URL, fileManager: FileManager) {
+    init(workingDir: URL, metaWriter: MetaWriter, fileManager: FileManager) {
         self.workingDir = workingDir
+        self.metaWriter = metaWriter
         self.fileManager = fileManager
     }
 
@@ -35,18 +36,10 @@ class ZipArtifactCreator {
         let zipURL = workingDir.appendingPathComponent("\(artifactKey).zip")
         try fileManager.createDirectory(at: workingDir, withIntermediateDirectories: true, attributes: nil)
         // Include meta json to the artifact
-        let metaURL = try dumpMeta(meta)
+        let metaURL = try metaWriter.write(meta, locationDir: workingDir)
         let zipPaths = zipContent + [metaURL]
 
         try Zip.zipFiles(paths: zipPaths, zipFilePath: zipURL, password: nil, progress: nil)
         return Artifact(id: artifactKey, package: zipURL, meta: metaURL)
-    }
-
-    // Save meta to a local file
-    private func dumpMeta<T: Meta>(_ meta: T) throws -> URL {
-        let metaURL = workingDir.appendingPathComponent(meta.fileKey).appendingPathExtension("json")
-        let metaData = try metaEncoder.encode(meta)
-        try fileManager.spt_writeToFile(atPath: metaURL.path, contents: metaData)
-        return metaURL
     }
 }

--- a/Sources/XCRemoteCache/Commands/Plugins/Thinning/ThinningCreatorPlugin.swift
+++ b/Sources/XCRemoteCache/Commands/Plugins/Thinning/ThinningCreatorPlugin.swift
@@ -33,13 +33,16 @@ enum ThinningCreatorPluginError: Error {
 /// Warning! This plugin assumes that producer's DerivedData are always cleaned before a build
 class ThinningCreatorPlugin: ArtifactCreatorPlugin {
     private let targetTempDir: URL
+    private let modeMarkerPath: String
     private let dirScanner: DirScanner
 
     /// Default Initializer
     /// - Parameter targetTempDir: Location of current target-specific temp dir (TARGET_TEMP_DIR)
+    /// - Parameter modeMarkerPath: path of maker file that informs if a given target can reuse remote artifacts.
     /// - Parameter dirScanner: scanner to access disk and read files and directories hierarchy
-    init(targetTempDir: URL, dirScanner: DirScanner) {
+    init(targetTempDir: URL, modeMarkerPath: String, dirScanner: DirScanner) {
         self.targetTempDir = targetTempDir
+        self.modeMarkerPath = modeMarkerPath
         self.dirScanner = dirScanner
     }
 
@@ -57,20 +60,8 @@ class ThinningCreatorPlugin: ArtifactCreatorPlugin {
             let fileKey: String
         }
         let uploadedTargetArtifacts = try allURLs.compactMap { tempDir -> TargetTuple? in
-            // All targets that uploaded their artifacts, have it placed in the
-            // `$(TARGET_TEMP_DIR)/xccache/produced/{{fileKey}}.zip` location. Find all targets that have such a file
-
-            let targetGeneratedArtifactRootDir = tempDir
-                .appendingPathComponent("xccache")
-                .appendingPathComponent("produced")
-            guard try dirScanner.itemType(atPath: targetGeneratedArtifactRootDir.path) == ItemType.dir else {
-                // given target didn't generate any artifacts (e.g. it is never cached with XCRemoteCache)
-                return nil
-            }
-
-            let allFilesProduced = try dirScanner.items(at: targetGeneratedArtifactRootDir)
-            let allArtifacts = allFilesProduced.filter { $0.pathExtension == "zip" }
-            guard !allArtifacts.isEmpty else {
+            let potentialArtifacts = try findTargetPackageZip(tempDir: tempDir)
+            guard let allArtifacts = potentialArtifacts, !allArtifacts.isEmpty else {
                 // there is no generated *.zip file, so given target didn't create an artifact - it could be
                 // just a helper target (like the target we integrate this plugin with)
                 return nil
@@ -78,7 +69,7 @@ class ThinningCreatorPlugin: ArtifactCreatorPlugin {
             // Find {{fileKey}} based on the .zip file basename
             guard allArtifacts.count == 1 else {
                 throw ThinningCreatorPluginError.noSingleTargetArtifactsGenerated(
-                    rootDir: targetGeneratedArtifactRootDir
+                    rootDir: tempDir
                 )
             }
             let fileKey = allArtifacts[0].deletingPathExtension().lastPathComponent
@@ -94,6 +85,38 @@ class ThinningCreatorPlugin: ArtifactCreatorPlugin {
         let extraKeysTuples = uploadedTargetArtifacts
             .map { ("\(ThinningPlugin.fileKeyPrefix)\($0.targetName)", $0.fileKey) }
         return Dictionary(uniqueKeysWithValues: extraKeysTuples)
+    }
+
+    private func findTargetPackageZip(tempDir: URL) throws -> [URL]? {
+        // Producer mode:
+        // All targets that uploaded their artifacts, have it placed in the
+        // `$(TARGET_TEMP_DIR)/xccache/produced/{{fileKey}}.zip` location. Find all targets that have such a file
+        // ProducerFull mode:
+        // If a target reused already existing artifact, it still has `$(TARGET_TEMP_DIR)/rc.enabled` marker file
+        // and the reused zip is placed in:
+        // `$(TARGET_TEMP_DIR)/xccache/{{fileKey}}.zip` location.
+
+        let targetEnabledMarker = tempDir.appendingPathComponent(modeMarkerPath)
+        let targetReusedArtifactRootDir = tempDir.appendingPathComponent("xccache")
+        let targetGeneratedArtifactRootDir = tempDir
+            .appendingPathComponent("xccache")
+            .appendingPathComponent("produced")
+
+        let pathToDirWithZipArtifacts: URL
+        // try the ProducerFull mode path first
+        if try dirScanner.itemType(atPath: targetEnabledMarker.path) == ItemType.file {
+            pathToDirWithZipArtifacts = targetReusedArtifactRootDir
+        } else {
+            guard try dirScanner.itemType(atPath: targetGeneratedArtifactRootDir.path) == ItemType.dir else {
+                // given target didn't generate any artifacts (e.g. it is never cached with XCRemoteCache)
+                return nil
+            }
+            pathToDirWithZipArtifacts = targetGeneratedArtifactRootDir
+        }
+
+        let allFilesProduced = try dirScanner.items(at: pathToDirWithZipArtifacts)
+        let allArtifacts = allFilesProduced.filter { $0.pathExtension == "zip" }
+        return allArtifacts
     }
 
     func artifactToUpload(main: MainArtifactMeta) throws -> [Artifact] {

--- a/Sources/XCRemoteCache/Commands/Plugins/Thinning/ThinningCreatorPlugin.swift
+++ b/Sources/XCRemoteCache/Commands/Plugins/Thinning/ThinningCreatorPlugin.swift
@@ -103,10 +103,13 @@ class ThinningCreatorPlugin: ArtifactCreatorPlugin {
             .appendingPathComponent("produced")
 
         let pathToDirWithZipArtifacts: URL
-        // try the ProducerFull mode path first
+        // try the `.producerFull` scenario first (the artifact was not locally
+        // generated but just reused from the remote cache)
         if try dirScanner.itemType(atPath: targetEnabledMarker.path) == ItemType.file {
             pathToDirWithZipArtifacts = targetReusedArtifactRootDir
         } else {
+            // cover a case when a target was build locally and an artifact
+            // has just been created (locally)
             guard try dirScanner.itemType(atPath: targetGeneratedArtifactRootDir.path) == ItemType.dir else {
                 // given target didn't generate any artifacts (e.g. it is never cached with XCRemoteCache)
                 return nil

--- a/Sources/XCRemoteCache/Commands/Plugins/Thinning/ThinningCreatorPlugin.swift
+++ b/Sources/XCRemoteCache/Commands/Plugins/Thinning/ThinningCreatorPlugin.swift
@@ -61,18 +61,18 @@ class ThinningCreatorPlugin: ArtifactCreatorPlugin {
         }
         let uploadedTargetArtifacts = try allURLs.compactMap { tempDir -> TargetTuple? in
             let potentialArtifacts = try findTargetPackageZip(tempDir: tempDir)
-            guard let allArtifacts = potentialArtifacts, !allArtifacts.isEmpty else {
+            guard !potentialArtifacts.isEmpty else {
                 // there is no generated *.zip file, so given target didn't create an artifact - it could be
                 // just a helper target (like the target we integrate this plugin with)
                 return nil
             }
             // Find {{fileKey}} based on the .zip file basename
-            guard allArtifacts.count == 1 else {
+            guard potentialArtifacts.count == 1 else {
                 throw ThinningCreatorPluginError.noSingleTargetArtifactsGenerated(
                     rootDir: tempDir
                 )
             }
-            let fileKey = allArtifacts[0].deletingPathExtension().lastPathComponent
+            let fileKey = potentialArtifacts[0].deletingPathExtension().lastPathComponent
             // Taking target name from tempDir, which has a structures "*.build"
             let targetName = tempDir.deletingPathExtension().lastPathComponent
             return TargetTuple(targetName: targetName, fileKey: fileKey)
@@ -87,7 +87,7 @@ class ThinningCreatorPlugin: ArtifactCreatorPlugin {
         return Dictionary(uniqueKeysWithValues: extraKeysTuples)
     }
 
-    private func findTargetPackageZip(tempDir: URL) throws -> [URL]? {
+    private func findTargetPackageZip(tempDir: URL) throws -> [URL] {
         // Producer mode:
         // All targets that uploaded their artifacts, have it placed in the
         // `$(TARGET_TEMP_DIR)/xccache/produced/{{fileKey}}.zip` location. Find all targets that have such a file
@@ -112,7 +112,7 @@ class ThinningCreatorPlugin: ArtifactCreatorPlugin {
             // has just been created (locally)
             guard try dirScanner.itemType(atPath: targetGeneratedArtifactRootDir.path) == ItemType.dir else {
                 // given target didn't generate any artifacts (e.g. it is never cached with XCRemoteCache)
-                return nil
+                return []
             }
             pathToDirWithZipArtifacts = targetGeneratedArtifactRootDir
         }

--- a/Sources/XCRemoteCache/Commands/Plugins/Thinning/ThinningCreatorPlugin.swift
+++ b/Sources/XCRemoteCache/Commands/Plugins/Thinning/ThinningCreatorPlugin.swift
@@ -91,7 +91,7 @@ class ThinningCreatorPlugin: ArtifactCreatorPlugin {
         // Producer mode:
         // All targets that uploaded their artifacts, have it placed in the
         // `$(TARGET_TEMP_DIR)/xccache/produced/{{fileKey}}.zip` location. Find all targets that have such a file
-        // ProducerFull mode:
+        // ProducerFast mode:
         // If a target reused already existing artifact, it still has `$(TARGET_TEMP_DIR)/rc.enabled` marker file
         // and the reused zip is placed in:
         // `$(TARGET_TEMP_DIR)/xccache/{{fileKey}}.zip` location.
@@ -103,7 +103,7 @@ class ThinningCreatorPlugin: ArtifactCreatorPlugin {
             .appendingPathComponent("produced")
 
         let pathToDirWithZipArtifacts: URL
-        // try the `.producerFull` scenario first (the artifact was not locally
+        // try the `.producerFast` scenario first (the artifact was not locally
         // generated but just reused from the remote cache)
         if try dirScanner.itemType(atPath: targetEnabledMarker.path) == ItemType.file {
             pathToDirWithZipArtifacts = targetReusedArtifactRootDir

--- a/Sources/XCRemoteCache/Commands/Postbuild/Postbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/Postbuild.swift
@@ -128,7 +128,8 @@ class Postbuild {
         try generateFingerprintOverrides(contextSpecificFingerprint: fingerprint.contextSpecific)
     }
 
-    /// Builds an artifact package and uploads it to the remote server
+    /// Uploads only a meta to the remote server - useful when the file artifact (.zip) already exists on a remote
+    /// server and only a meta for a current commit sha has to be uploaded
     public func performMetaUpload(meta: MainArtifactMeta, for commit: String) throws {
         // Reset plugins keys as these are unique to each
         var meta = meta

--- a/Sources/XCRemoteCache/Commands/Postbuild/PostbuildContext.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/PostbuildContext.swift
@@ -73,6 +73,7 @@ public struct PostbuildContext {
     var thinnedTargets: [String]
     /// Action type: build, indexbuild etc.
     var action: BuildActionType
+    let modeMarkerPath: String
 }
 
 extension PostbuildContext {
@@ -115,5 +116,6 @@ extension PostbuildContext {
         let thinFocusedTargetsString: String = env.readEnv(key: "SPT_XCREMOTE_CACHE_THINNED_TARGETS") ?? ""
         thinnedTargets = thinFocusedTargetsString.split(separator: ",").map(String.init)
         action = (try? BuildActionType(rawValue: env.readEnv(key: "ACTION"))) ?? .unknown
+        modeMarkerPath = config.modeMarkerPath
     }
 }

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -276,9 +276,8 @@ public class XCPostbuild {
             } else {
                 try postbuildAction.performBuildCleanup()
                 try cacheHitLogger.logMiss()
-                // Producer mode doesn't use cached artifacts so modeController is not enabled. If producer
-                // reaches this point, there were no issues with publishing
-                let actionName = context.mode == .producer ? "Published" : "Disabled"
+                // If producers reach this point, there were no issues with publishing
+                let actionName = context.mode == .consumer ? "Disabled" : "Published"
                 printToUser("\(actionName) remote cache for \(context.targetName)")
             }
         } catch PluginError.unrecoverableError(let error) {

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -85,6 +85,7 @@ public class XCPostbuild {
                 algorithm: MD5Algorithm()
             )
             let organizer = ZipArtifactOrganizer(targetTempDir: context.targetTempDir, fileManager: fileManager)
+            let metaWriter = JsonMetaWriter(fileWriter: fileManager)
             let artifactCreator = BuildArtifactCreator(
                 buildDir: context.productsDir,
                 tempDir: context.targetTempDir,
@@ -92,6 +93,7 @@ public class XCPostbuild {
                 moduleName: context.moduleName,
                 modulesFolderPath: context.modulesFolderPath,
                 dSYMPath: context.dSYMPath,
+                metaWriter: metaWriter,
                 fileManager: fileManager
             )
             let dirAccessor = DirAccessorComposer(
@@ -230,6 +232,7 @@ public class XCPostbuild {
                 dSYMOrganizer: dSYMOrganizer,
                 modeController: modeController,
                 metaReader: metaReader,
+                metaWriter: metaWriter,
                 creatorPlugins: creatorPlugins,
                 consumerPlugins: consumerPlugins
             )

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -249,6 +249,12 @@ public class XCPostbuild {
                 // Generate artifacts and upload to the remote server for a reference sha
                 let referenceCommit = try config.publishingSha ?? gitClient.getCurrentSha()
                 try postbuildAction.performBuildUpload(for: referenceCommit)
+            } else if try context.mode == .producerFast && !modeController.isEnabled() {
+                // Generate artifacts and upload to the remote server for a reference sha
+                let referenceCommit = try config.publishingSha ?? gitClient.getCurrentSha()
+                let metaData = try remoteNetworkClient.fetch(.meta(commit: referenceCommit))
+                let meta = try metaReader.read(data: metaData)
+                try postbuildAction.performMetaUpload(meta: meta, for: referenceCommit)
             }
 
             let executableURL = context.productsDir.appendingPathComponent(context.executablePath)

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -205,9 +205,10 @@ public class XCPostbuild {
                             worker: DispatchGroupParallelizationWorker(qos: .userInitiated)
                         )
                         consumerPlugins.append(thinningPlugin)
-                    case .producer:
+                    case .producer, .producerFast:
                         let thinningPlugin = ThinningCreatorPlugin(
                             targetTempDir: context.targetTempDir,
+                            modeMarkerPath: context.modeMarkerPath,
                             dirScanner: fileManager
                         )
                         creatorPlugins.append(thinningPlugin)

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -249,14 +249,14 @@ public class XCPostbuild {
 
 
             // Trigger uploading the artifact
-            switch (context.mode, try modeController.isEnabled()) {
-            case (.producerFast, true):
+            switch (context.mode, try modeController.isEnabled(), context.remoteCommit) {
+            case (.producerFast, true, .available(commit: let commitToReuse)):
                 // Upload only updated meta. Artifact zip is already on a remote server
                 let referenceCommit = try config.publishingSha ?? gitClient.getCurrentSha()
-                let metaData = try remoteNetworkClient.fetch(.meta(commit: referenceCommit))
+                let metaData = try remoteNetworkClient.fetch(.meta(commit: commitToReuse))
                 let meta = try metaReader.read(data: metaData)
                 try postbuildAction.performMetaUpload(meta: meta, for: referenceCommit)
-            case (.producer, _), (.producerFast, _):
+            case (.producer, _, _), (.producerFast, _, _):
                 // Generate artifacts and upload to the remote server for a reference sha
                 let referenceCommit = try config.publishingSha ?? gitClient.getCurrentSha()
                 try postbuildAction.performBuildUpload(for: referenceCommit)

--- a/Sources/XCRemoteCache/Commands/Swiftc/Swiftc.swift
+++ b/Sources/XCRemoteCache/Commands/Swiftc/Swiftc.swift
@@ -120,9 +120,9 @@ class Swiftc: SwiftcProtocol {
                 let prebuildDiscoveryURL = context.tempDir.appendingPathComponent(context.prebuildDependenciesPath)
                 let prebuildDiscoverWriter = dependenciesWriterFactory(prebuildDiscoveryURL, fileManager)
                 try prebuildDiscoverWriter.write(skipForSha: remoteCommit)
-            case .consumer, .producer:
-                // Never skips prebuild phase and fallbacks to the swiftc compilation for:
-                // 1) Not enabled remote cache or 2) producer
+            case .consumer, .producer, .producerFast:
+                // Never skip prebuild phase and fallback to the swiftc compilation for:
+                // 1) Not enabled remote cache, 2) producer(s)
                 break
             }
             return .forceFallback

--- a/Sources/XCRemoteCache/Commands/Swiftc/SwiftcContext.swift
+++ b/Sources/XCRemoteCache/Commands/Swiftc/SwiftcContext.swift
@@ -24,7 +24,7 @@ public struct SwiftcContext {
         case producer
         /// Commit sha of the commit to use during remote cache
         case consumer(commit: RemoteCommitInfo)
-        /// Remote artifact exists and can be optimistically used in lieu of a local compilation
+        /// Remote artifact exists and can be optimistically used in place of a local compilation
         case producerFast
     }
 

--- a/Sources/XCRemoteCache/Commands/Swiftc/SwiftcContext.swift
+++ b/Sources/XCRemoteCache/Commands/Swiftc/SwiftcContext.swift
@@ -24,6 +24,8 @@ public struct SwiftcContext {
         case producer
         /// Commit sha of the commit to use during remote cache
         case consumer(commit: RemoteCommitInfo)
+        /// Remote artifact exists and can be optimistically used in lieu of a local compilation
+        case producerFast
     }
 
     let objcHeaderOutput: URL
@@ -74,6 +76,14 @@ public struct SwiftcContext {
             mode = .consumer(commit: remoteCommit)
         case .producer:
             mode = .producer
+        case .producerFast:
+            let remoteCommit = RemoteCommitInfo(try? String(contentsOf: remoteCommitLocation).trim())
+            switch remoteCommit {
+            case .unavailable:
+                mode = .producer
+            case .available:
+                mode = .producerFast
+            }
         }
         invocationHistoryFile = URL(fileURLWithPath: config.compilationHistoryFile, relativeTo: tempDir)
     }

--- a/Sources/XCRemoteCache/Commands/Swiftc/SwiftcOrchestrator.swift
+++ b/Sources/XCRemoteCache/Commands/Swiftc/SwiftcOrchestrator.swift
@@ -116,6 +116,12 @@ class SwiftcOrchestrator {
             }
         case .consumer:
             fallbackToDefault(command: swiftcCommand)
+        case .producerFast:
+            let compileStepResult = try swiftc.mockCompilation()
+            if case .forceFallback = compileStepResult {
+                // cannot reuse cached artifact. Build it locally and upload to the server just as for the producer
+                fallthrough
+            }
         case .producer:
             var swiftcArgs = ProcessInfo().arguments
             swiftcArgs = try producerFallbackCommandProcessors.reduce(swiftcArgs) { args, processor in

--- a/Sources/XCRemoteCache/Config/Mode.swift
+++ b/Sources/XCRemoteCache/Config/Mode.swift
@@ -20,4 +20,5 @@
 public enum Mode: String, Codable, CaseIterable {
     case consumer
     case producer
+    case producerFast
 }

--- a/Sources/XCRemoteCache/Models/MetaWriter.swift
+++ b/Sources/XCRemoteCache/Models/MetaWriter.swift
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+protocol MetaWriter {
+    func write<T>(_ meta: T, locationDir : URL) throws -> URL where T : Meta
+}
+
+class JsonMetaWriter: MetaWriter {
+    private let metaEncoder = JSONEncoder()
+    private let fileWriter: FileWriter
+
+    init(fileWriter: FileWriter) {
+        self.fileWriter = fileWriter
+    }
+
+    func write<T>(_ meta: T, locationDir : URL) throws -> URL where T : Meta {
+        let metaURL = locationDir.appendingPathComponent(meta.fileKey).appendingPathExtension("json")
+        let metaData = try metaEncoder.encode(meta)
+        try fileWriter.write(toPath: metaURL.path, contents: metaData)
+        return metaURL
+    }
+}

--- a/Sources/XCRemoteCache/Network/RemoteNetworkClientAbstractFactory.swift
+++ b/Sources/XCRemoteCache/Network/RemoteNetworkClientAbstractFactory.swift
@@ -44,7 +44,7 @@ class RemoteNetworkClientAbstractFactory {
             return RemoteNetworkClientImpl(networkClient, downloadURLBuilder)
         }
         switch mode {
-        case .producer:
+        case .producer, .producerFast:
             let upstreamBuilders = try upstreamStreamURL.map(urlBuilderFactory)
             return ReplicatedRemotesNetworkClient(
                 networkClient,

--- a/Tests/XCRemoteCacheTests/Artifacts/BuildArtifactCreatorTests.swift
+++ b/Tests/XCRemoteCacheTests/Artifacts/BuildArtifactCreatorTests.swift
@@ -63,6 +63,7 @@ class BuildArtifactCreatorTests: FileXCTestCase {
             moduleName: "Target",
             modulesFolderPath: "",
             dSYMPath: dSYM,
+            metaWriter: JsonMetaWriter(fileWriter: fileManager),
             fileManager: fileManager
         )
     }

--- a/Tests/XCRemoteCacheTests/Artifacts/ZipArtifactCreatorTests.swift
+++ b/Tests/XCRemoteCacheTests/Artifacts/ZipArtifactCreatorTests.swift
@@ -35,7 +35,11 @@ class ZipArtifactCreatorTests: FileXCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         workingDir = try prepareTempDir().appendingPathComponent("creator")
-        creator = ZipArtifactCreator(workingDir: workingDir, fileManager: fileManager)
+        creator = ZipArtifactCreator(
+            workingDir: workingDir,
+            metaWriter: JsonMetaWriter(fileWriter: fileManager),
+            fileManager: fileManager
+        )
     }
 
     func testCreatingArtifactGeneratesValidArtifactId() throws {

--- a/Tests/XCRemoteCacheTests/Commands/Plugins/Thinning/ThinningCreatorPluginTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/Plugins/Thinning/ThinningCreatorPluginTests.swift
@@ -33,7 +33,10 @@ class ThinningCreatorPluginTests: FileXCTestCase {
         targetTempDirRoot = workingDir.appendingPathComponent("Root")
         currentTargetTempDir = targetTempDirRoot.appendingPathComponent("Current.build")
         try fileManager.spt_createEmptyDir(currentTargetTempDir)
-        plugin = ThinningCreatorPlugin(targetTempDir: currentTargetTempDir, dirScanner: FileManager.default)
+        plugin = ThinningCreatorPlugin(
+            targetTempDir: currentTargetTempDir,
+            modeMarkerPath: "rc.enabled",
+            dirScanner: FileManager.default)
     }
 
     func testReturnsEmptyExtraKeysForNoArtifacts() throws {

--- a/Tests/XCRemoteCacheTests/Commands/Plugins/Thinning/ThinningCreatorPluginTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/Plugins/Thinning/ThinningCreatorPluginTests.swift
@@ -35,7 +35,7 @@ class ThinningCreatorPluginTests: FileXCTestCase {
         try fileManager.spt_createEmptyDir(currentTargetTempDir)
         plugin = ThinningCreatorPlugin(
             targetTempDir: currentTargetTempDir,
-            modeMarkerPath: "rc.enabled",
+            modeMarkerPath: "rc_marker.enabled",
             dirScanner: FileManager.default)
     }
 
@@ -79,7 +79,7 @@ class ThinningCreatorPluginTests: FileXCTestCase {
 
     func testDefinesExtraMetaKeysForTargetsThatReusedArtifact() throws {
         let otherTargetTempDir = targetTempDirRoot.appendingPathComponent("Other.build")
-        let marker = otherTargetTempDir.appendingPathComponent("rc.enabled")
+        let marker = otherTargetTempDir.appendingPathComponent("rc_marker.enabled")
         let reusedArtifact = otherTargetTempDir
             .appendingPathComponent("xccache")
             .appendingPathComponent("123")
@@ -94,7 +94,7 @@ class ThinningCreatorPluginTests: FileXCTestCase {
 
     func testFailsGeneratingExtraMetaKeysForTwoArtifactsInTargetTempDir() throws {
         let otherTargetTempDir = targetTempDirRoot.appendingPathComponent("Other.build")
-        let marker = otherTargetTempDir.appendingPathComponent("rc.enabled")
+        let marker = otherTargetTempDir.appendingPathComponent("rc_marker.enabled")
         let reusedArtifact1 = otherTargetTempDir
             .appendingPathComponent("xccache")
             .appendingPathComponent("001")
@@ -119,7 +119,7 @@ class ThinningCreatorPluginTests: FileXCTestCase {
             .appendingPathExtension("zip")
         try fileManager.spt_createEmptyFile(generatedArtifact)
         let reusedTargetTempDir = targetTempDirRoot.appendingPathComponent("Reused.build")
-        let marker = reusedTargetTempDir.appendingPathComponent("rc.enabled")
+        let marker = reusedTargetTempDir.appendingPathComponent("rc_marker.enabled")
         let reusedArtifact = reusedTargetTempDir
             .appendingPathComponent("xccache")
             .appendingPathComponent("999")

--- a/Tests/XCRemoteCacheTests/Commands/PostbuildTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/PostbuildTests.swift
@@ -50,7 +50,8 @@ class PostbuildTests: FileXCTestCase {
         bundleDir: nil,
         derivedSourcesDir: "",
         thinnedTargets: [],
-        action: .build
+        action: .build,
+        modeMarkerPath: ""
     )
     private var network = RemoteNetworkClientImpl(
         NetworkClientFake(fileManager: .default),

--- a/Tests/XCRemoteCacheTests/Commands/SwiftcContextTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/SwiftcContextTests.swift
@@ -62,4 +62,19 @@ class SwiftcContextTests: FileXCTestCase {
 
         XCTAssertEqual(context.mode, .consumer(commit: .unavailable))
     }
+
+    func testProducerModeWhenFileWithCommitShaExistsIsResolvedToProducerFast() throws {
+        config.mode = .producerFast
+        let context = try SwiftcContext(config: config, input: input)
+
+        XCTAssertEqual(context.mode, .producerFast)
+    }
+
+    func testProducerModeWhenFileWithCommitShaDoesntExxistIsResolvedToProducer() throws {
+        config.mode = .producerFast
+        try fileManager.spt_deleteItem(at: remoteCommitFile)
+        let context = try SwiftcContext(config: config, input: input)
+
+        XCTAssertEqual(context.mode, .producer)
+    }
 }

--- a/Tests/XCRemoteCacheTests/Commands/SwiftcOrchestratorTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/SwiftcOrchestratorTests.swift
@@ -211,7 +211,7 @@ class SwiftcOrchestratorTests: XCTestCase {
         XCTAssertEqual(artifactBuilder.addedObjCHeaders, ["archTest": [objcHeaderURL]])
     }
 
-    func testSuccessedMockInProducerFastModeModeDoesntFillObjCHeader() throws {
+    func testSuccessedMockInProducerFastModeDoesntFillObjCHeader() throws {
         let swiftc = SwiftcMock(mockingResult: .success)
         let orchestrator = SwiftcOrchestrator(
             mode: .producerFast,

--- a/Tests/XCRemoteCacheTests/Commands/SwiftcOrchestratorTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/SwiftcOrchestratorTests.swift
@@ -190,4 +190,45 @@ class SwiftcOrchestratorTests: XCTestCase {
 
         XCTAssertNotNil(shellOutSpy.switchedProcess)
     }
+
+    func testForFailedCompilationMockInProducerFastModeBuildsArtifactObjCHeader() throws {
+        let swiftc = SwiftcMock(mockingResult: .forceFallback)
+        let orchestrator = SwiftcOrchestrator(
+            mode: .producerFast,
+            swiftc: swiftc,
+            swiftcCommand: "",
+            objcHeaderOutput: objcHeaderURL,
+            moduleOutput: moduleOutputURL,
+            arch: "archTest",
+            artifactBuilder: artifactBuilder,
+            producerFallbackCommandProcessors: [],
+            invocationStorage: invocationStorage,
+            shellOut: shellOutSpy
+        )
+
+        try orchestrator.run()
+
+        XCTAssertEqual(artifactBuilder.addedObjCHeaders, ["archTest": [objcHeaderURL]])
+    }
+
+    func testSuccessedMockInProducerFastModeModeDoesntFillObjCHeader() throws {
+        let swiftc = SwiftcMock(mockingResult: .success)
+        let orchestrator = SwiftcOrchestrator(
+            mode: .producerFast,
+            swiftc: swiftc,
+            swiftcCommand: "",
+            objcHeaderOutput: objcHeaderURL,
+            moduleOutput: moduleOutputURL,
+            arch: "arch",
+            artifactBuilder: artifactBuilder,
+            producerFallbackCommandProcessors: [],
+            invocationStorage: invocationStorage,
+            shellOut: shellOutSpy
+        )
+
+        try orchestrator.run()
+
+        XCTAssertEqual(artifactBuilder.addedObjCHeaders, [:])
+    }
+
 }

--- a/Tests/XCRemoteCacheTests/Config/ModeTests.swift
+++ b/Tests/XCRemoteCacheTests/Config/ModeTests.swift
@@ -17,8 +17,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-public enum Mode: String, Codable, CaseIterable {
-    case consumer
-    case producer
-    case producerFast = "producer-fast"
+@testable import XCRemoteCache
+import XCTest
+import Yams
+
+class ModeTests: XCTestCase {
+
+    func testProducerFast() throws {
+        let yaml = "producer-fast"
+        let decoder = YAMLDecoder(encoding: .utf8)
+        let mode: Mode = try decoder.decode(from: yaml)
+
+        XCTAssertEqual(mode, .producerFast)
+    }
 }

--- a/Tests/XCRemoteCacheTests/Models/JsonMetaWriterTests.swift
+++ b/Tests/XCRemoteCacheTests/Models/JsonMetaWriterTests.swift
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@testable import XCRemoteCache
+import XCTest
+
+class JsonMetaWriterTests: XCTestCase {
+
+    func testWritesToFileWithFilekeyFilename() throws {
+        let fileAccessor = FileAccessorFake(mode: .normal)
+        let writer = JsonMetaWriter(fileWriter: fileAccessor)
+        let workingDir: URL = "/"
+        let meta = MainArtifactSampleMeta.defaults
+
+        let url = try writer.write(MainArtifactSampleMeta.defaults, locationDir: workingDir)
+
+        XCTAssertEqual(url, workingDir.appendingPathComponent(meta.fileKey).appendingPathExtension("json"))
+    }
+
+    func testWritesMetaInValidFormat() throws {
+        let fileAccessor = FileAccessorFake(mode: .normal)
+        let writer = JsonMetaWriter(fileWriter: fileAccessor)
+        let reader = JsonMetaReader(fileAccessor: fileAccessor)
+        let workingDir: URL = "/"
+        let meta = MainArtifactSampleMeta.defaults
+
+        let url = try writer.write(MainArtifactSampleMeta.defaults, locationDir: workingDir)
+
+        let readMeta = try reader.read(localFile: url)
+        XCTAssertEqual(readMeta, meta)
+    }
+}


### PR DESCRIPTION
Adding a new (experimental) mode: `producer-fast`.

`producer-fast` is a mode similar to `producer`, but tries to reuse existing artifacts on a remote server. The flow is as follows:
* For each target, in a build process try to reuse artifacts (similar to the `consumer` mode)
* If all was fine, in a xcpostbuild only upload new meta file with almost the same content, but a different commit sha so consumers will be able to download it right away, e.g. `7672c431b312649b5de5b0bb25d6b66637d7e9bc-targetName-Debug-iphonesimulator-13A233-febe8bf27e87b274a94539b439169394.json` is uploaded to `c53a24c019c717a50e5d072d1862276f15c90bf2-targetName-Debug-iphonesimulator-13A233-febe8bf27e87b274a94539b439169394.json`, where `7672c431b312649b5de5b0bb25d6b66637d7e9bc` is a previous commit sha that the artifact was reused and `c53a24c019c717a50e5d072d1862276f15c90bf2` is current sha that we run a build
* If local compilation was forced (source code has changed), just follow the flow of the `producer`
* Bonus: _experimental "thinning plugin" had to be updated to always refer up-to-date artifacts (either built locally or reused)._