### PR TITLE
Inspect code coverage with CLANG_COVERAGE_MAPPING ENV

### DIFF
--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -27,7 +27,7 @@ public enum XCRemoteCacheConfigError: Error {
 
 public struct XCRemoteCacheConfig: Encodable {
     /// Remote cache schema version. Bump that version if RC artifact generation introduces breaking changes
-    let schemaVersion = "6"
+    let schemaVersion = "5"
     /// Mode: consumer|producer, defaults to consumer
     var mode: Mode = .consumer
     /// Address of all remote cache replicas. The best one (with the quickest response) will be chose in xcprepare step

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -27,7 +27,7 @@ public enum XCRemoteCacheConfigError: Error {
 
 public struct XCRemoteCacheConfig: Encodable {
     /// Remote cache schema version. Bump that version if RC artifact generation introduces breaking changes
-    let schemaVersion = "5"
+    let schemaVersion = "6"
     /// Mode: consumer|producer, defaults to consumer
     var mode: Mode = .consumer
     /// Address of all remote cache replicas. The best one (with the quickest response) will be chose in xcprepare step

--- a/Sources/XCRemoteCache/Fingerprint/EnvironmentFingerprint.swift
+++ b/Sources/XCRemoteCache/Fingerprint/EnvironmentFingerprint.swift
@@ -22,7 +22,7 @@ class EnvironmentFingerprintGenerator {
     /// Default ENV variables constituing the environment fingerprint
     private static let defaultEnvFingerprintKeys = [
         "GCC_PREPROCESSOR_DEFINITIONS",
-        "CLANG_PROFILE_DATA_DIRECTORY",
+        "CLANG_COVERAGE_MAPPING",
         "TARGET_NAME",
         "CONFIGURATION",
         "PLATFORM_NAME",

--- a/Tests/XCRemoteCacheTests/Fingerprint/EnvironmentFingerprintGeneratorTests.swift
+++ b/Tests/XCRemoteCacheTests/Fingerprint/EnvironmentFingerprintGeneratorTests.swift
@@ -24,7 +24,7 @@ class EnvironmentFingerprintGeneratorTests: XCTestCase {
 
     private static let defaultENV = [
         "GCC_PREPROCESSOR_DEFINITIONS": "GCC",
-        "CLANG_PROFILE_DATA_DIRECTORY": "CLANG",
+        "CLANG_COVERAGE_MAPPING": "YES",
         "TARGET_NAME": "TARGET",
         "CONFIGURATION": "CONG",
         "PLATFORM_NAME": "PLAT",
@@ -35,7 +35,7 @@ class EnvironmentFingerprintGeneratorTests: XCTestCase {
         "PRODUCT_MODULE_NAME": "4",
     ]
     /// Corresponds to EnvironmentFingerprintGenerator.version
-    private static let currentVersion = "5"
+    private static let currentVersion = "6"
 
     private var config: XCRemoteCacheConfig!
     private var generator: FingerprintAccumulator!
@@ -55,7 +55,7 @@ class EnvironmentFingerprintGeneratorTests: XCTestCase {
     func testConsidersDefaultEnvs() throws {
         let fingerprint = try fingerprintGenerator.generateFingerprint()
 
-        XCTAssertEqual(fingerprint, "GCC,CLANG,TARGET,CONG,PLAT,XC,1,2,3,4,\(Self.currentVersion)")
+        XCTAssertEqual(fingerprint, "GCC,YES,TARGET,CONG,PLAT,XC,1,2,3,4,\(Self.currentVersion)")
     }
 
     func testFingerprintIncludesVersionAsLastComponent() throws {
@@ -89,6 +89,6 @@ class EnvironmentFingerprintGeneratorTests: XCTestCase {
 
         let fingerprint = try fingerprintGenerator.generateFingerprint()
 
-        XCTAssertEqual(fingerprint, "GCC,CLANG,TARGET,CONG,PLAT,XC,1,2,3,4,CUSTOM_VALUE,\(Self.currentVersion)")
+        XCTAssertEqual(fingerprint, "GCC,YES,TARGET,CONG,PLAT,XC,1,2,3,4,CUSTOM_VALUE,\(Self.currentVersion)")
     }
 }

--- a/Tests/XCRemoteCacheTests/Fingerprint/EnvironmentFingerprintGeneratorTests.swift
+++ b/Tests/XCRemoteCacheTests/Fingerprint/EnvironmentFingerprintGeneratorTests.swift
@@ -35,7 +35,7 @@ class EnvironmentFingerprintGeneratorTests: XCTestCase {
         "PRODUCT_MODULE_NAME": "4",
     ]
     /// Corresponds to EnvironmentFingerprintGenerator.version
-    private static let currentVersion = "6"
+    private static let currentVersion = "5"
 
     private var config: XCRemoteCacheConfig!
     private var generator: FingerprintAccumulator!


### PR DESCRIPTION
Replacing ENV `CLANG_PROFILE_DATA_DIRECTORY ` with `CLANG_COVERAGE_MAPPING` when generating an environment fingerprint. 

`CLANG_PROFILE_DATA_DIRECTORY` was added to make artifacts with enabled/disabled code coverage exclusive. That value is `""` for a build with disabled code coverage and contains an absolute path like 
`/Users/somePath/DerivedData/ProjectName/Build/ProfileData` when building with code coverage. To not lead into cache miss when absolute paths are different on a consumer and producer (very likely), `CLANG_COVERAGE_MAPPING` can be used instead. Its value is simple:
* code coverage enabled -> `YES`
* code coverage disabled -> `""` (not defined)

Fixes #31