### PR TITLE
Switch to Xcode 13.1 for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
   macOS:
     runs-on: macOS-latest
     env:
-      XCODE_VERSION: ${{ '12.4' }}
+      XCODE_VERSION: ${{ '13.1' }}
     steps:
       - name: Select Xcode
         run: "sudo xcode-select -s /Applications/Xcode_$XCODE_VERSION.app"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Add macOS binaries to release
     runs-on: macOS-latest
     env:
-      XCODE_VERSION: ${{ '12.4' }}
+      XCODE_VERSION: ${{ '13.1' }}
     steps:
       - name: Select Xcode
         run: "sudo xcode-select -s /Applications/Xcode_$XCODE_VERSION.app"


### PR DESCRIPTION
The latest macos (macos 11.6), already supports Xcode 13.1:
https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md