### PR TITLE
Add out_of_band mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ _Note that for the `producer` mode, the prebuild build phase and `xccc`, `xcld`,
 | `aws_access_key` | Access key for AWS V4 Signature Authorization. | `""` | ⬜️ |
 | `aws_region` | Region for AWS V4 Signature Authorization. E.g. `eu`.  | `""` | ⬜️ |
 | `aws_service` | Service for AWS V4 Signature Authorization. E.g. `storage`. | `""` | ⬜️ |
+| `out_of_band_mappings` | A dictionary of files path remapping that should be applied to make it absolute path agnostic on a list of dependencies. Useful if a project refers files out of repo root, either compilation files or precompiled dependencies. Keys represent generic replacement and values are substrings that should be replaced. Example: for mapping `["COOL_LIBRARY": "/CoolLibrary"]` `/CoolLibrary/main.swift`will be represented as `$(COOL_LIBRARY)/main.swift`). Warning: remapping order is not-deterministic so avoid remappings with multiple matchings. | `[:]` | ⬜️ |
 
 
 ## Backend cache server

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -67,7 +67,7 @@ public class XCPostbuild {
             let primaryGitBranch = GitBranch(repoLocation: config.primaryRepo, branch: config.primaryBranch)
             let gitClient = GitClientImpl(repoRoot: config.repoRoot, primary: primaryGitBranch, shell: shellGetStdout)
             let pathRemapper = try StringDependenciesRemapperFactory().build(
-                orderKeys: DependenciesMapping.rewrittenEnvs + config.outOfBandMappings.keys,
+                orderKeys: DependenciesMapping.rewrittenEnvs,
                 envs: env,
                 customMappings: config.outOfBandMappings
             )

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -70,17 +70,11 @@ public class XCPostbuild {
                 keys: DependenciesMapping.rewrittenEnvs,
                 envs: env
             )
-            let pathRemapper: DependenciesRemapper
-            if config.outOfBandMappings.isEmpty {
-                pathRemapper = envRemapper
-            } else {
-                let outOfBandMappings: [StringDependenciesRemapper.Mapping] = config.outOfBandMappings.reduce([]) { (prev, arg1) in
-                    let (local, generic) = arg1
-                    return prev + [.init(generic: generic, local: local)]
-                }
-                let outOfBandRemapper = StringDependenciesRemapper(mappings: outOfBandMappings)
-                pathRemapper = DependenciesRemapperComposite([envRemapper, outOfBandRemapper])
+            let customOutOfBandMappings = config.outOfBandMappings.map { (local, generic) in
+                StringDependenciesRemapper.Mapping(generic: generic, local: local)
             }
+            let outOfBandRemapper = StringDependenciesRemapper(mappings: customOutOfBandMappings)
+            let pathRemapper = DependenciesRemapperComposite([envRemapper, outOfBandRemapper])
             let envFingerprint = try EnvironmentFingerprintGenerator(
                 configuration: config,
                 env: env,

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -66,11 +66,10 @@ public class XCPostbuild {
             // Initialize dependencies
             let primaryGitBranch = GitBranch(repoLocation: config.primaryRepo, branch: config.primaryBranch)
             let gitClient = GitClientImpl(repoRoot: config.repoRoot, primary: primaryGitBranch, shell: shellGetStdout)
-            let pathRemapper = try StringDependenciesRemapper.buildFromEnvs(
-                keys: DependenciesMapping.rewrittenEnvs + config.outOfBandMappings.keys,
-                envs: env.merging(config.outOfBandMappings) { envValue, outOfBandMapping in
-                    outOfBandMapping
-                }
+            let pathRemapper = try StringDependenciesRemapperFactory().build(
+                orderKeys: DependenciesMapping.rewrittenEnvs + config.outOfBandMappings.keys,
+                envs: env,
+                customMappings: config.outOfBandMappings
             )
             let envFingerprint = try EnvironmentFingerprintGenerator(
                 configuration: config,

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -71,10 +71,10 @@ public class XCPostbuild {
                 envs: env
             )
             let pathRemapper: DependenciesRemapper
-            if config.outOfBandMapping.isEmpty {
+            if config.outOfBandMappings.isEmpty {
                 pathRemapper = envRemapper
             } else {
-                let outOfBandMappings: [StringDependenciesRemapper.Mapping] = config.outOfBandMapping.reduce([]) { (prev, arg1) in
+                let outOfBandMappings: [StringDependenciesRemapper.Mapping] = config.outOfBandMappings.reduce([]) { (prev, arg1) in
                     let (local, generic) = arg1
                     return prev + [.init(generic: generic, local: local)]
                 }

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -66,15 +66,12 @@ public class XCPostbuild {
             // Initialize dependencies
             let primaryGitBranch = GitBranch(repoLocation: config.primaryRepo, branch: config.primaryBranch)
             let gitClient = GitClientImpl(repoRoot: config.repoRoot, primary: primaryGitBranch, shell: shellGetStdout)
-            let envRemapper = try StringDependenciesRemapper.buildFromEnvs(
-                keys: DependenciesMapping.rewrittenEnvs,
-                envs: env
+            let pathRemapper = try StringDependenciesRemapper.buildFromEnvs(
+                keys: DependenciesMapping.rewrittenEnvs + config.outOfBandMappings.keys,
+                envs: env.merging(config.outOfBandMappings) { envValue, outOfBandMapping in
+                    outOfBandMapping
+                }
             )
-            let customOutOfBandMappings = config.outOfBandMappings.map { (local, generic) in
-                StringDependenciesRemapper.Mapping(generic: generic, local: local)
-            }
-            let outOfBandRemapper = StringDependenciesRemapper(mappings: customOutOfBandMappings)
-            let pathRemapper = DependenciesRemapperComposite([envRemapper, outOfBandRemapper])
             let envFingerprint = try EnvironmentFingerprintGenerator(
                 configuration: config,
                 env: env,

--- a/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
@@ -120,10 +120,10 @@ public class XCPrebuild {
                 envs: env
             )
             let pathRemapper: DependenciesRemapper
-            if config.outOfBandMapping.isEmpty {
+            if config.outOfBandMappings.isEmpty {
                 pathRemapper = envRemapper
             } else {
-                let outOfBandMappings: [StringDependenciesRemapper.Mapping] = config.outOfBandMapping.reduce([]) { (prev, arg1) in
+                let outOfBandMappings: [StringDependenciesRemapper.Mapping] = config.outOfBandMappings.reduce([]) { (prev, arg1) in
                     let (local, generic) = arg1
                     return prev + [.init(generic: generic, local: local)]
                 }

--- a/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
@@ -115,15 +115,12 @@ public class XCPrebuild {
             )
             let client: NetworkClient = config.disableHttpCache ? networkClient : cacheNetworkClient
             let remoteNetworkClient = RemoteNetworkClientImpl(client, urlBuilder)
-            let envRemapper = try StringDependenciesRemapper.buildFromEnvs(
-                keys: DependenciesMapping.rewrittenEnvs,
-                envs: env
+            let pathRemapper = try StringDependenciesRemapper.buildFromEnvs(
+                keys: DependenciesMapping.rewrittenEnvs + config.outOfBandMappings.keys,
+                envs: env.merging(config.outOfBandMappings) { envValue, outOfBandMapping in
+                    outOfBandMapping
+                }
             )
-            let customOutOfBandMappings = config.outOfBandMappings.map { (local, generic) in
-                StringDependenciesRemapper.Mapping(generic: generic, local: local)
-            }
-            let outOfBandRemapper = StringDependenciesRemapper(mappings: customOutOfBandMappings)
-            let pathRemapper = DependenciesRemapperComposite([envRemapper, outOfBandRemapper])
             let filesFingerprintGenerator = FingerprintAccumulatorImpl(
                 algorithm: MD5Algorithm(),
                 fileManager: fileManager

--- a/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
@@ -116,7 +116,7 @@ public class XCPrebuild {
             let client: NetworkClient = config.disableHttpCache ? networkClient : cacheNetworkClient
             let remoteNetworkClient = RemoteNetworkClientImpl(client, urlBuilder)
             let pathRemapper = try StringDependenciesRemapperFactory().build(
-                orderKeys: DependenciesMapping.rewrittenEnvs + config.outOfBandMappings.keys,
+                orderKeys: DependenciesMapping.rewrittenEnvs,
                 envs: env,
                 customMappings: config.outOfBandMappings
             )

--- a/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
@@ -115,11 +115,10 @@ public class XCPrebuild {
             )
             let client: NetworkClient = config.disableHttpCache ? networkClient : cacheNetworkClient
             let remoteNetworkClient = RemoteNetworkClientImpl(client, urlBuilder)
-            let pathRemapper = try StringDependenciesRemapper.buildFromEnvs(
-                keys: DependenciesMapping.rewrittenEnvs + config.outOfBandMappings.keys,
-                envs: env.merging(config.outOfBandMappings) { envValue, outOfBandMapping in
-                    outOfBandMapping
-                }
+            let pathRemapper = try StringDependenciesRemapperFactory().build(
+                orderKeys: DependenciesMapping.rewrittenEnvs + config.outOfBandMappings.keys,
+                envs: env,
+                customMappings: config.outOfBandMappings
             )
             let filesFingerprintGenerator = FingerprintAccumulatorImpl(
                 algorithm: MD5Algorithm(),

--- a/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
@@ -119,17 +119,11 @@ public class XCPrebuild {
                 keys: DependenciesMapping.rewrittenEnvs,
                 envs: env
             )
-            let pathRemapper: DependenciesRemapper
-            if config.outOfBandMappings.isEmpty {
-                pathRemapper = envRemapper
-            } else {
-                let outOfBandMappings: [StringDependenciesRemapper.Mapping] = config.outOfBandMappings.reduce([]) { (prev, arg1) in
-                    let (local, generic) = arg1
-                    return prev + [.init(generic: generic, local: local)]
-                }
-                let outOfBandRemapper = StringDependenciesRemapper(mappings: outOfBandMappings)
-                pathRemapper = DependenciesRemapperComposite([envRemapper, outOfBandRemapper])
+            let customOutOfBandMappings = config.outOfBandMappings.map { (local, generic) in
+                StringDependenciesRemapper.Mapping(generic: generic, local: local)
             }
+            let outOfBandRemapper = StringDependenciesRemapper(mappings: customOutOfBandMappings)
+            let pathRemapper = DependenciesRemapperComposite([envRemapper, outOfBandRemapper])
             let filesFingerprintGenerator = FingerprintAccumulatorImpl(
                 algorithm: MD5Algorithm(),
                 fileManager: fileManager

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -122,6 +122,8 @@ public struct XCRemoteCacheConfig: Encodable {
     var AWSRegion: String = ""
     /// Service for AWS V4 Signature (e.g. `storage`)
     var AWSService: String = ""
+    /// dependency path => generic path
+    var outOfBandMapping: [String: String] = [:]
 }
 
 extension XCRemoteCacheConfig {
@@ -172,6 +174,7 @@ extension XCRemoteCacheConfig {
         merge.AWSSecretKey = scheme.AWSSecretKey ?? AWSSecretKey
         merge.AWSRegion = scheme.AWSRegion ?? AWSRegion
         merge.AWSService = scheme.AWSService ?? AWSService
+        merge.outOfBandMapping = scheme.outOfBandMapping ?? outOfBandMapping
         return merge
     }
 
@@ -231,6 +234,7 @@ struct ConfigFileScheme: Decodable {
     let AWSAccessKey: String?
     let AWSRegion: String?
     let AWSService: String?
+    let outOfBandMapping: [String: String]?
 
     // Yams library doesn't support encoding strategy, see https://github.com/jpsim/Yams/issues/84
     enum CodingKeys: String, CodingKey {
@@ -273,6 +277,7 @@ struct ConfigFileScheme: Decodable {
         case AWSAccessKey = "aws_access_key"
         case AWSRegion = "aws_region"
         case AWSService = "aws_service"
+        case outOfBandMapping = "out_of_band_mapping"
     }
 }
 

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -124,7 +124,10 @@ public struct XCRemoteCacheConfig: Encodable {
     var AWSService: String = ""
     /// A Dictionary of source files remapping that should be applied to make it absolute paths agnostic.
     /// Useful if a project refers compilation files of precompiled dependencies placed out of repo root
-    /// Keys represent local paths to replace with corresponding values (e.g. ["/coolLibrary": '$(COOL_LIBRARY)"]
+    /// Keys represent generic replacement of given values (e.g. for `["COOL_LIBRARY": "/CoolLibrary"]`,
+    /// `/CoolLibrary/main.swift` in a list of dependencies will be replaced with `$(COOL_LIBRARY)/main.swift`)
+    /// Warning: remapping order is not-deterministic so avoid remappings with multiple matchings
+
     /// Warning: mapping order is not-deterministic so avoid remapping with multiple-matches
     var outOfBandMappings: [String: String] = [:]
 }

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -122,13 +122,12 @@ public struct XCRemoteCacheConfig: Encodable {
     var AWSRegion: String = ""
     /// Service for AWS V4 Signature (e.g. `storage`)
     var AWSService: String = ""
-    /// A Dictionary of source files remapping that should be applied to make it absolute paths agnostic.
-    /// Useful if a project refers compilation files of precompiled dependencies placed out of repo root
-    /// Keys represent generic replacement of given values (e.g. for `["COOL_LIBRARY": "/CoolLibrary"]`,
-    /// `/CoolLibrary/main.swift` in a list of dependencies will be replaced with `$(COOL_LIBRARY)/main.swift`)
-    /// Warning: remapping order is not-deterministic so avoid remappings with multiple matchings
-
-    /// Warning: mapping order is not-deterministic so avoid remapping with multiple-matches
+    /// A dictionary of files path remapping that should be applied to make it absolute path agnostic on a list of dependencies.
+    /// Useful if a project refers files out of repo root, either compilation files or precompiled dependencies.
+    /// Keys represent generic replacement and values are substrings that should be replaced.
+    /// Example: for mapping `["COOL_LIBRARY": "/CoolLibrary"]`
+    /// `/CoolLibrary/main.swift`will be represented as `$(COOL_LIBRARY)/main.swift`).
+    /// Warning: remapping order is not-deterministic so avoid remappings with multiple matchings.
     var outOfBandMappings: [String: String] = [:]
 }
 

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -122,8 +122,11 @@ public struct XCRemoteCacheConfig: Encodable {
     var AWSRegion: String = ""
     /// Service for AWS V4 Signature (e.g. `storage`)
     var AWSService: String = ""
-    /// dependency path => generic path
-    var outOfBandMapping: [String: String] = [:]
+    /// A Dictionary of source files remapping that should be applied to make it absolute paths agnostic.
+    /// Useful if a project refers compilation files of precompiled dependencies placed out of repo root
+    /// Keys represent local paths to replace with corresponding values (e.g. ["/coolLibrary": '$(COOL_LIBRARY)"]
+    /// Warning: mapping order is not-deterministic so avoid remapping with multiple-matches
+    var outOfBandMappings: [String: String] = [:]
 }
 
 extension XCRemoteCacheConfig {
@@ -174,7 +177,7 @@ extension XCRemoteCacheConfig {
         merge.AWSSecretKey = scheme.AWSSecretKey ?? AWSSecretKey
         merge.AWSRegion = scheme.AWSRegion ?? AWSRegion
         merge.AWSService = scheme.AWSService ?? AWSService
-        merge.outOfBandMapping = scheme.outOfBandMapping ?? outOfBandMapping
+        merge.outOfBandMappings = scheme.outOfBandMappings ?? outOfBandMappings
         return merge
     }
 
@@ -234,7 +237,7 @@ struct ConfigFileScheme: Decodable {
     let AWSAccessKey: String?
     let AWSRegion: String?
     let AWSService: String?
-    let outOfBandMapping: [String: String]?
+    let outOfBandMappings: [String: String]?
 
     // Yams library doesn't support encoding strategy, see https://github.com/jpsim/Yams/issues/84
     enum CodingKeys: String, CodingKey {
@@ -277,7 +280,7 @@ struct ConfigFileScheme: Decodable {
         case AWSAccessKey = "aws_access_key"
         case AWSRegion = "aws_region"
         case AWSService = "aws_service"
-        case outOfBandMapping = "out_of_band_mapping"
+        case outOfBandMappings = "out_of_band_mappings"
     }
 }
 

--- a/Sources/XCRemoteCache/Dependencies/DependenciesRemapper.swift
+++ b/Sources/XCRemoteCache/Dependencies/DependenciesRemapper.swift
@@ -35,7 +35,7 @@ class DependenciesRemapperComposite: DependenciesRemapper {
     }
 
     func replace(genericPaths: [String]) -> [String] {
-        remappers.reduce(genericPaths) { prev, mapper in
+        remappers.reversed().reduce(genericPaths) { prev, mapper in
             mapper.replace(genericPaths: prev)
         }
     }

--- a/Sources/XCRemoteCache/Dependencies/DependenciesRemapper.swift
+++ b/Sources/XCRemoteCache/Dependencies/DependenciesRemapper.swift
@@ -61,7 +61,7 @@ final class StringDependenciesRemapper: DependenciesRemapper {
 
     func replace(genericPaths: [String]) -> [String] {
         return genericPaths.map { path in
-            let localPath = mappings.reduce(path) { prevPath, mapping in
+            let localPath = mappings.reversed().reduce(path) { prevPath, mapping in
                 prevPath.replacingOccurrences(of: mapping.generic, with: mapping.local)
             }
             return localPath

--- a/Sources/XCRemoteCache/Dependencies/DependenciesRemapper.swift
+++ b/Sources/XCRemoteCache/Dependencies/DependenciesRemapper.swift
@@ -77,14 +77,3 @@ final class StringDependenciesRemapper: DependenciesRemapper {
         }
     }
 }
-
-
-extension StringDependenciesRemapper {
-    static func buildFromEnvs(keys: [String], envs: [String: String]) throws -> Self {
-        let mappings: [Mapping] = try keys.map { key in
-            let localValue: String = try envs.readEnv(key: key)
-            return Mapping(generic: "$(\(key))", local: localValue)
-        }
-        return Self(mappings: mappings)
-    }
-}

--- a/Sources/XCRemoteCache/Dependencies/StringDependenciesRemapperFactory.swift
+++ b/Sources/XCRemoteCache/Dependencies/StringDependenciesRemapperFactory.swift
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+enum StringDependenciesRemapperFactoryError: Error {
+    /// Remapping keys are duplicated and can lead to undetermined results
+    case mappingKeyDuplication
+}
+
+class StringDependenciesRemapperFactory {
+    func build(
+        orderKeys: [String],
+        envs: [String: String],
+        customMappings: [String: String]
+    ) throws -> StringDependenciesRemapper {
+        let mappingMap = try envs.merging(customMappings) { envValue, outOfBandMapping in
+            throw StringDependenciesRemapperFactoryError.mappingKeyDuplication
+        }
+        let mappingOrderKeys =  orderKeys + customMappings.keys
+        let mappings: [StringDependenciesRemapper.Mapping] = try mappingOrderKeys.map { key in
+            let localValue: String = try mappingMap.readEnv(key: key)
+            return StringDependenciesRemapper.Mapping(generic: "$(\(key))", local: localValue)
+        }
+        return StringDependenciesRemapper(mappings: mappings)
+    }
+}

--- a/Tests/XCRemoteCacheTests/Dependencies/DependenciesRemapperCompositeTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/DependenciesRemapperCompositeTests.swift
@@ -103,7 +103,7 @@ class DependenciesRemapperCompositeTests: XCTestCase {
         XCTAssertEqual(localPaths, ["/root/specific/file"])
     }
 
-    func testRemappingBackAndForthIsIdentity() throws {
+    func testRemappingTwoMappingsBackAndForthIsIdentical() throws {
         let remapper = DependenciesRemapperComposite([
             StringDependenciesRemapper(mappings: [StringDependenciesRemapper.Mapping(generic: "$(ROOT)", local: "/root")]),
             StringDependenciesRemapper(mappings: [StringDependenciesRemapper.Mapping(generic: "$(SPECIFIC)", local: "$(ROOT)/specific")])

--- a/Tests/XCRemoteCacheTests/Dependencies/StringDependenciesRemapperFactoryTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/StringDependenciesRemapperFactoryTests.swift
@@ -1,0 +1,71 @@
+// Copyright (c) 2021 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@testable import XCRemoteCache
+import XCTest
+
+class StringDependenciesRemapperFactoryTests: XCTestCase {
+    private var factory: StringDependenciesRemapperFactory!
+
+    override func setUp() {
+        factory = StringDependenciesRemapperFactory()
+    }
+
+    func testMappingsFromEnvMaps() throws {
+        let remapper = try factory.build(
+            orderKeys: ["SRC_ROOT"],
+            envs: ["SRC_ROOT": "/tmp/root"],
+            customMappings: [:]
+        )
+
+        let localPaths = remapper.replace(genericPaths: ["$(SRC_ROOT)/some.swift"])
+        XCTAssertEqual(localPaths, ["/tmp/root/some.swift"])
+    }
+
+    func testInvalidMappingsFromEnvFails() throws {
+        XCTAssertThrowsError(
+            try factory.build(
+                orderKeys: ["SRC_ROOT"],
+                envs: ["NO_SRC_ROOT": ""],
+                customMappings: [:]
+            )
+        )
+    }
+
+    func testBuildingRemapperWithMergedCustomMappings() throws {
+        let remapper = try factory.build(
+            orderKeys: ["PWD"],
+            envs: ["PWD": "/some"],
+            customMappings: ["TMP": "/tmp"]
+        )
+
+        let genericPaths = remapper.replace(localPaths: ["/some/repoFile.swift", "/tmp/externalFile.swift"])
+        XCTAssertEqual(genericPaths, ["$(PWD)/repoFile.swift", "$(TMP)/externalFile.swift"])
+    }
+
+    func testFailsBuildingRemapperWithConflictedMappings() throws {
+        XCTAssertThrowsError(
+            try factory.build(
+            orderKeys: ["PWD"],
+            envs: ["PWD": "/some"],
+            customMappings: ["PWD": "/other"]
+            )
+        )
+    }
+}

--- a/Tests/XCRemoteCacheTests/Dependencies/StringDependenciesRemapperTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/StringDependenciesRemapperTests.swift
@@ -70,20 +70,6 @@ class StringDependenciesRemapperTests: XCTestCase {
         XCTAssertEqual(genericPaths, ["$(SRC_ROOT)/some.swift", "$(PWD)/extra.swift"])
     }
 
-    func testMappingsFromEnvMaps() throws {
-        remapper = try StringDependenciesRemapper.buildFromEnvs(keys: ["SRC_ROOT"], envs: ["SRC_ROOT": "/tmp/root"])
-
-        let localPaths = remapper.replace(genericPaths: ["$(SRC_ROOT)/some.swift"])
-
-        XCTAssertEqual(localPaths, ["/tmp/root/some.swift"])
-    }
-
-    func testInvalidMappingsFromEnvFAils() throws {
-        XCTAssertThrowsError(
-            try StringDependenciesRemapper.buildFromEnvs(keys: ["SRC_ROOT"], envs: ["NO_SRC_ROOT": ""])
-        )
-    }
-
     func testMappingsLocalPathsIsDoneInOrder() {
         let mappings: [StringDependenciesRemapper.Mapping] = [
             .init(generic: "$(TMP)", local: "/tmp"),

--- a/Tests/XCRemoteCacheTests/Dependencies/StringDependenciesRemapperTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/StringDependenciesRemapperTests.swift
@@ -83,4 +83,30 @@ class StringDependenciesRemapperTests: XCTestCase {
             try StringDependenciesRemapper.buildFromEnvs(keys: ["SRC_ROOT"], envs: ["NO_SRC_ROOT": ""])
         )
     }
+
+    func testMappingsLocalPathsIsDoneInOrder() {
+        let mappings: [StringDependenciesRemapper.Mapping] = [
+            .init(generic: "$(TMP)", local: "/tmp"),
+            .init(generic: "$(ROOT)", local: "$(TMP)/root"),
+        ]
+        remapper = StringDependenciesRemapper(mappings: mappings)
+
+
+        let genericPaths = remapper.replace(localPaths: ["/tmp/root/some.swift"])
+
+        XCTAssertEqual(genericPaths, ["$(ROOT)/some.swift"])
+    }
+
+    func testMappingsGenericPathsIsDoneInReversedOrder() {
+        let mappings: [StringDependenciesRemapper.Mapping] = [
+            .init(generic: "$(TMP)", local: "/tmp"),
+            .init(generic: "$(ROOT)", local: "$(TMP)/root"),
+        ]
+        remapper = StringDependenciesRemapper(mappings: mappings)
+
+
+        let localPaths = remapper.replace(genericPaths: ["$(ROOT)/some.swift"])
+
+        XCTAssertEqual(localPaths, ["/tmp/root/some.swift"])
+    }
 }


### PR DESCRIPTION
Introduces a new configuration parameter to remap external (or complex) path location on a list of dependencies files.

Usecases:
* Some files in a build are placed in a known, yet dynamic location
* Build process has modes that place source files in different locations