### PR TITLE
Patch PLATFORM_PREFERRED_ARCH to support native Apple Silicon builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Configure Xcode targets that **should use** XCRemoteCache:
 * `SWIFT_EXEC` - location of `xcprepare` (e.g. `xcremotecache/xcswiftc`)
 * `LIBTOOL` - location of `xclibtool` (e.g. `xcremotecache/xclibtool`)
 * `LD` - location of `xcld` (e.g. `xcremotecache/xcld`)
+* `XCRC_PLATFORM_PREFERRED_ARCH` - `$(LINK_FILE_LIST_$(CURRENT_VARIANT)_$(PLATFORM_PREFERRED_ARCH):dir:standardizepath:file:default=arm64)`
 
 <details>
   <summary>Screenshot</summary>
@@ -215,8 +216,8 @@ Configure Xcode targets that **should use** XCRemoteCache:
 * command: `"$SCRIPT_INPUT_FILE_0"`
 * input files: location of `xcpostbuild` command (e.g. `xcremotecache/xcpostbuild`)
 * output files: 
-  * `$(TARGET_BUILD_DIR)/$(MODULES_FOLDER_PATH)/$(PRODUCT_MODULE_NAME).swiftmodule/$(PLATFORM_PREFERRED_ARCH).swiftmodule.md5`
-  * `$(TARGET_BUILD_DIR)/$(MODULES_FOLDER_PATH)/$(PRODUCT_MODULE_NAME).swiftmodule/$(PLATFORM_PREFERRED_ARCH)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)$(LLVM_TARGET_TRIPLE_SUFFIX).swiftmodule.md5`
+  * `$(TARGET_BUILD_DIR)/$(MODULES_FOLDER_PATH)/$(PRODUCT_MODULE_NAME).swiftmodule/$(XCRC_PLATFORM_PREFERRED_ARCH).swiftmodule.md5`
+  * `$(TARGET_BUILD_DIR)/$(MODULES_FOLDER_PATH)/$(PRODUCT_MODULE_NAME).swiftmodule/$(XCRC_PLATFORM_PREFERRED_ARCH)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)$(LLVM_TARGET_TRIPLE_SUFFIX).swiftmodule.md5`
 * discovery dependency file: `$(TARGET_TEMP_DIR)/postbuild.d`
 
 <details>

--- a/Sources/XCRemoteCache/Commands/Prepare/Integrate/BuildSettingsIntegrateAppender.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/Integrate/BuildSettingsIntegrateAppender.swift
@@ -62,6 +62,7 @@ class XcodeProjBuildSettingsIntegrateAppender: BuildSettingsIntegrateAppender {
         result["OTHER_CFLAGS"] = clangFlags.settingValue
 
         result["XCRC_FAKE_SRCROOT"] = "/\(String(repeating: "x", count: 10))"
+        result["XCRC_PLATFORM_PREFERRED_ARCH"] = "$(LINK_FILE_LIST_$(CURRENT_VARIANT)_$(PLATFORM_PREFERRED_ARCH):dir:standardizepath:file:default=arm64)"
         return result
     }
 }

--- a/Sources/XCRemoteCache/Commands/Prepare/Integrate/XcodeProjIntegrate.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/Integrate/XcodeProjIntegrate.swift
@@ -100,11 +100,11 @@ struct XcodeProjIntegrate: Integrate {
             outputPaths: [
                 """
                 $(TARGET_BUILD_DIR)/$(MODULES_FOLDER_PATH)/$(PRODUCT_MODULE_NAME).swiftmodule/\
-                $(PLATFORM_PREFERRED_ARCH).swiftmodule.md5
+                $(XCRC_PLATFORM_PREFERRED_ARCH).swiftmodule.md5
                 """,
                 """
                 $(TARGET_BUILD_DIR)/$(MODULES_FOLDER_PATH)/$(PRODUCT_MODULE_NAME).swiftmodule/\
-                $(PLATFORM_PREFERRED_ARCH)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)\
+                $(XCRC_PLATFORM_PREFERRED_ARCH)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)\
                 $(LLVM_TARGET_TRIPLE_SUFFIX).swiftmodule.md5
                 """,
             ],

--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
@@ -115,6 +115,7 @@ module CocoapodsXCRemoteCacheModifier
           config.build_settings['LD'] = ["$SRCROOT/#{srcroot_relative_xc_location}/xcld"]
 
           config.build_settings['XCREMOTE_CACHE_FAKE_SRCROOT'] = FAKE_SRCROOT
+          config.build_settings['XCRC_PLATFORM_PREFERRED_ARCH'] = ["$(LINK_FILE_LIST_$(CURRENT_VARIANT)_$(PLATFORM_PREFERRED_ARCH):dir:standardizepath:file:default=arm64)"]
           debug_prefix_map_replacement = '$(SRCROOT' + ':dir:standardizepath' * repo_distance + ')'
           add_cflags!(config.build_settings, '-fdebug-prefix-map', "#{debug_prefix_map_replacement}=$(XCREMOTE_CACHE_FAKE_SRCROOT)")
           add_swiftflags!(config.build_settings, '-debug-prefix-map', "#{debug_prefix_map_replacement}=$(XCREMOTE_CACHE_FAKE_SRCROOT)")
@@ -157,8 +158,8 @@ module CocoapodsXCRemoteCacheModifier
         postbuild_script.shell_script = "\"$SCRIPT_INPUT_FILE_0\""
         postbuild_script.input_paths = ["$SRCROOT/#{srcroot_relative_xc_location}/xcpostbuild"]
         postbuild_script.output_paths = [
-          "$(TARGET_BUILD_DIR)/$(MODULES_FOLDER_PATH)/$(PRODUCT_MODULE_NAME).swiftmodule/$(PLATFORM_PREFERRED_ARCH).swiftmodule.md5",
-          "$(TARGET_BUILD_DIR)/$(MODULES_FOLDER_PATH)/$(PRODUCT_MODULE_NAME).swiftmodule/$(PLATFORM_PREFERRED_ARCH)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)$(LLVM_TARGET_TRIPLE_SUFFIX).swiftmodule.md5"
+          "$(TARGET_BUILD_DIR)/$(MODULES_FOLDER_PATH)/$(PRODUCT_MODULE_NAME).swiftmodule/$(XCRC_PLATFORM_PREFERRED_ARCH).swiftmodule.md5",
+          "$(TARGET_BUILD_DIR)/$(MODULES_FOLDER_PATH)/$(PRODUCT_MODULE_NAME).swiftmodule/$(XCRC_PLATFORM_PREFERRED_ARCH)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)$(LLVM_TARGET_TRIPLE_SUFFIX).swiftmodule.md5"
         ]
         postbuild_script.dependency_file = "$(TARGET_TEMP_DIR)/postbuild.d"
 

--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module CocoapodsXcremotecache
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
Fixing a path to the xcpostbuild output file location for build for simulator on M1 machines. 

### Context
When building on Intel machines, PLATFORM_PREFERRED_ARCH correctly resolves to the "main" architecture of the build. Simulator - `x86_64`, Hardware iPhone - `arm64`, hardware AppleWatch - `arm64_32` etc.
However, when building on M1 for a native simulator, it resolves to `x86_64`, even a build compiles only for `arm64`.  This apparently is a bug (filed FB9824531) which could potentially lead to incorrectly skipped `xcpostbuild` build step (Xcode would look for a non-existing file in the `x86_64` directory, which doesn't exist as relevant files will be placed in `arm64` directory).

### The workaround
The fix for the producer side has been merged in  #39 - instead of relying on `PLATFORM_PREFERRED_ARCH`, the first architecture in `ARCHS` is used.
On the consumer side that Build Setting is used also to define `xcpostbuild` output files. The list of Build Settings operations is **very** limited so the fix had to use complex settings operations. For more details about available operations, see WWDC 2021 [session](https://developer.apple.com/videos/play/wwdc2021/10210/).

#### Patching `PLATFORM_PREFERRED_ARCH`
In essence, we need to replace `PLATFORM_PREFERRED_ARCH` to `arm64` when building for simulator on Apple Silicon machines. I found that for such case `LINK_FILE_LIST_normal_$(PLATFORM_PREFERRED_ARCH)` is empty (not defined). 
The idea is to check if there is a build setting `LINK_FILE_LIST_normal_{expected_arch}`. If not, we are in a scenario with a bug so have to fallback to `arm64`. 
`LINK_FILE_LIST_normal_{ARCH}` env has a path to the `LinkFileList` file which is placed in a dir `{ARCH}` so the trick is to extract that value for the non-buggy scenario (see the example below).

##### M1 machine example

```
CURRENT_VARIANT=normal
PLATFORM_PREFERRED_ARCH=x86_64
LINK_FILE_LIST_normal_arm64=DerivedData/Project/Build/Intermediates.noindex/Project.build/Debug-iphonesimulator/T.build/Objects-normal/arm64/T.LinkFileList
LINK_FILE_LIST_normal_x86_64= ## empty as not defined
```
| Key | Value | 
|---|---|
| `LINK_FILE_LIST_$(CURRENT_VARIANT)_$(PLATFORM_PREFERRED_ARCH)` | `LINK_FILE_LIST_normal_x86_64` |
`$(LINK_FILE_LIST_$(CURRENT_VARIANT)_$(PLATFORM_PREFERRED_ARCH))` |  `` |
`$(LINK_FILE_LIST_$(CURRENT_VARIANT)_$(PLATFORM_PREFERRED_ARCH):dir)`   |   `` |
`$(LINK_FILE_LIST_$(CURRENT_VARIANT)_$(PLATFORM_PREFERRED_ARCH):dir:standardizepath)`  |    `` |
`$(LINK_FILE_LIST_$(CURRENT_VARIANT)_$(PLATFORM_PREFERRED_ARCH):dir:standardizepath:file)`  |    `` |
`$(LINK_FILE_LIST_$(CURRENT_VARIANT)_$(PLATFORM_PREFERRED_ARCH):dir:standardizepath:file:default=arm64)` |  `arm64` |


##### Intel machine example

```
CURRENT_VARIANT=normal
PLATFORM_PREFERRED_ARCH=x86_64
LINK_FILE_LIST_normal_x86_64=DerivedData/Project/Build/Intermediates.noindex/Project.build/Debug-iphonesimulator/T.build/Objects-normal/x86_64/T.LinkFileList
```
| Key | Value | 
|---|---|
| `LINK_FILE_LIST_$(CURRENT_VARIANT)_$(PLATFORM_PREFERRED_ARCH)` | `LINK_FILE_LIST_normal_x86_64`  |
`$(LINK_FILE_LIST_$(CURRENT_VARIANT)_$(PLATFORM_PREFERRED_ARCH))` | `DerivedData/Project/Build/Intermediates.noindex/Project.build/Debug-iphonesimulator/T.build/Objects-normal/x86_64/T.LinkFileList` |  
`$(LINK_FILE_LIST_$(CURRENT_VARIANT)_$(PLATFORM_PREFERRED_ARCH):dir)`   | `DerivedData/Project/Build/Intermediates.noindex/Project.build/Debug-iphonesimulator/T.build/Objects-normal/x86_64/` |
`$(LINK_FILE_LIST_$(CURRENT_VARIANT)_$(PLATFORM_PREFERRED_ARCH):dir:standardizepath)`  |  `DerivedData/Project/Build/Intermediates.noindex/Project.build/Debug-iphonesimulator/T.build/Objects-normal/x86_64` |
`$(LINK_FILE_LIST_$(CURRENT_VARIANT)_$(PLATFORM_PREFERRED_ARCH):dir:standardizepath:file)`  |  `x86_64`|
`$(LINK_FILE_LIST_$(CURRENT_VARIANT)_$(PLATFORM_PREFERRED_ARCH):dir:standardizepath:file:default=arm64)` |`x86_64`  |