### PR TITLE
Always include ARCHS in a fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,6 @@ Create `.rcinfo` yaml file next to the `.xcodeproj` with a minimum set of config
 primary_repo: https://yourRepo.git
 cache_addresses:
 - https://xcremotecacheserver.com
-custom_fingerprint_envs: 
-- ARCHS
 ```
 
 #### 3. Run automatic integration script
@@ -375,11 +373,6 @@ _If all of your machines (both producer and all consumers have the same architec
 
 XCRemoteCache supports building artifacts for Apple silicon consumers. Is it recommended to build separately for `x86_64` and `arm64` architectures to have single-architecture artifacts that do not require downloading irrelevant binaries. Here are required steps if you want to support both Intel and Apple silicon consumers.
 
-* Add `ARCHS` to `custom_fingerprint_envs` in your `.rcinfo`, e.g.
-```
-custom_fingerprint_envs: 
-  - ARCHS
-```
 * Building for a simulator on a producer: run a first build for `x86_64`, clean a build and build again for `arm64`, e.g.:
 ```
 xcodebuild ARCHS=x86_64 ONLY_ACTIVE_ARCH=NO build ...

--- a/Sources/XCRemoteCache/Fingerprint/EnvironmentFingerprint.swift
+++ b/Sources/XCRemoteCache/Fingerprint/EnvironmentFingerprint.swift
@@ -19,7 +19,7 @@
 
 /// Generates a fingerprint string of the environment (compilation context)
 class EnvironmentFingerprintGenerator {
-    /// Default ENV variables constituing the environment fingerprint
+    /// Default ENV variables constituting the environment fingerprint
     private static let defaultEnvFingerprintKeys = [
         "GCC_PREPROCESSOR_DEFINITIONS",
         "CLANG_COVERAGE_MAPPING",
@@ -31,6 +31,7 @@ class EnvironmentFingerprintGenerator {
         "DYLIB_COMPATIBILITY_VERSION",
         "DYLIB_CURRENT_VERSION",
         "PRODUCT_MODULE_NAME",
+        "ARCHS"
     ]
     private let version: String
     private let customFingerprintEnvs: [String]

--- a/Tests/XCRemoteCacheTests/Fingerprint/EnvironmentFingerprintGeneratorTests.swift
+++ b/Tests/XCRemoteCacheTests/Fingerprint/EnvironmentFingerprintGeneratorTests.swift
@@ -33,6 +33,7 @@ class EnvironmentFingerprintGeneratorTests: XCTestCase {
         "DYLIB_COMPATIBILITY_VERSION": "2",
         "DYLIB_CURRENT_VERSION": "3",
         "PRODUCT_MODULE_NAME": "4",
+        "ARCHS": "AR"
     ]
     /// Corresponds to EnvironmentFingerprintGenerator.version
     private static let currentVersion = "5"
@@ -55,7 +56,7 @@ class EnvironmentFingerprintGeneratorTests: XCTestCase {
     func testConsidersDefaultEnvs() throws {
         let fingerprint = try fingerprintGenerator.generateFingerprint()
 
-        XCTAssertEqual(fingerprint, "GCC,YES,TARGET,CONG,PLAT,XC,1,2,3,4,\(Self.currentVersion)")
+        XCTAssertEqual(fingerprint, "GCC,YES,TARGET,CONG,PLAT,XC,1,2,3,4,AR,\(Self.currentVersion)")
     }
 
     func testFingerprintIncludesVersionAsLastComponent() throws {
@@ -73,7 +74,7 @@ class EnvironmentFingerprintGeneratorTests: XCTestCase {
 
         let fingerprint = try fingerprintGenerator.generateFingerprint()
 
-        XCTAssertEqual(fingerprint, ",,,,,,,,,,\(Self.currentVersion)")
+        XCTAssertEqual(fingerprint, ",,,,,,,,,,,\(Self.currentVersion)")
     }
 
     func testConsidersCustomEnvs() throws {
@@ -89,6 +90,6 @@ class EnvironmentFingerprintGeneratorTests: XCTestCase {
 
         let fingerprint = try fingerprintGenerator.generateFingerprint()
 
-        XCTAssertEqual(fingerprint, "GCC,YES,TARGET,CONG,PLAT,XC,1,2,3,4,CUSTOM_VALUE,\(Self.currentVersion)")
+        XCTAssertEqual(fingerprint, "GCC,YES,TARGET,CONG,PLAT,XC,1,2,3,4,AR,CUSTOM_VALUE,\(Self.currentVersion)")
     }
 }


### PR DESCRIPTION
Always include `ARCHS` ENV in the fingerprint. It is required to support Apple Silicon - `iphonesimulator` platform might build for `arm64` and `x86_64` and zip artifacts for these architectures need to be unique.

#39 follow-up