### PR TITLE
Add support for generate_multiple_pod_projects

### DIFF
--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module CocoapodsXcremotecache
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
This small modification add antegration to multiple generated projects.

It's a bit hacky, because `Pod::Installer` is not available inside hooks that are registered through `Pod::HooksManager`. It only provides `Pod::Installer::PostInstallHooksContext`, so a small workaround takes place.

There's also some boilerplate code happenned there. Maybe I should merge two arrays before iterating?

And I also added check to non-empty source file list (like in command-line tool)