### PR TITLE
Limit integrating CocoaPods to native targets

### DIFF
--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
@@ -378,6 +378,8 @@ module CocoapodsXCRemoteCacheModifier
             installer_context.pods_project.targets.each do |target|
                 next if target.name.start_with?("Pods-")
                 next if target.name.end_with?("Tests")
+                # Enable only for native targets which can have compilation steps
+                next unless target.instance_of?(Xcodeproj::Project::Object::PBXNativeTarget)
                 next if exclude_targets.include?(target.name)
                 enable_xcremotecache(target, 1, xcrc_location, xccc_location, mode, exclude_build_configurations, final_target)
             end

--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
@@ -375,9 +375,8 @@ module CocoapodsXCRemoteCacheModifier
           # Always integrate XCRemoteCache to all Pods, in case it will be needed later
           unless installer_context.pods_project.nil?
             # Attach XCRemoteCache to Pods targets
-            installer_context.pods_project.targets.each do |target|
-                # Enable only for native targets which can have compilation steps
-                next unless target.instance_of?(Xcodeproj::Project::Object::PBXNativeTarget)
+            # Enable only for native targets which can have compilation steps
+            installer_context.pods_project.native_targets.each do |target|
                 next if target.source_build_phase.files_references.empty?
                 next if target.name.start_with?("Pods-")
                 next if target.name.end_with?("Tests")
@@ -392,7 +391,6 @@ module CocoapodsXCRemoteCacheModifier
             installer_context.pods_project.root_object.project_references.each do |subproj_ref|
                 generated_project = Xcodeproj::Project.open("#{pods_proj_directory}/#{subproj_ref[:project_ref].path}")
                 generated_project.native_targets.each do |target|
-                    next unless target.instance_of?(Xcodeproj::Project::Object::PBXNativeTarget)
                     next if target.source_build_phase.files_references.empty?
                     next if target.name.end_with?("Tests")
                     next if exclude_targets.include?(target.name)

--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
@@ -376,11 +376,11 @@ module CocoapodsXCRemoteCacheModifier
           unless installer_context.pods_project.nil?
             # Attach XCRemoteCache to Pods targets
             installer_context.pods_project.targets.each do |target|
+                # Enable only for native targets which can have compilation steps
+                next unless target.instance_of?(Xcodeproj::Project::Object::PBXNativeTarget)
                 next if target.source_build_phase.files_references.empty?
                 next if target.name.start_with?("Pods-")
                 next if target.name.end_with?("Tests")
-                # Enable only for native targets which can have compilation steps
-                next unless target.instance_of?(Xcodeproj::Project::Object::PBXNativeTarget)
                 next if exclude_targets.include?(target.name)
                 enable_xcremotecache(target, 1, xcrc_location, xccc_location, mode, exclude_build_configurations, final_target)
             end
@@ -392,6 +392,7 @@ module CocoapodsXCRemoteCacheModifier
             installer_context.pods_project.root_object.project_references.each do |subproj_ref|
                 generated_project = Xcodeproj::Project.open("#{pods_proj_directory}/#{subproj_ref[:project_ref].path}")
                 generated_project.native_targets.each do |target|
+                    next unless target.instance_of?(Xcodeproj::Project::Object::PBXNativeTarget)
                     next if target.source_build_phase.files_references.empty?
                     next if target.name.end_with?("Tests")
                     next if exclude_targets.include?(target.name)


### PR DESCRIPTION
CocoaPods plugin was incorrectly trying to integrate into aggregation targets, which don't have compilation steps to cache. 

The automation integrator is limiting XCRemoteCache integration to native targets only: 
https://github.com/spotify/XCRemoteCache/blob/cdddc5bf194045c6860ace14f9c8cf7d4da5185e/Sources/XCRemoteCache/Commands/Prepare/Integrate/XcodeProjIntegrate.swift#L185

Fixes #60