### PR TITLE
Resolve symlinks and dirpaths in dependency processor

### DIFF
--- a/Sources/XCRemoteCache/Dependencies/DependencyProcessor.swift
+++ b/Sources/XCRemoteCache/Dependencies/DependencyProcessor.swift
@@ -58,11 +58,11 @@ class DependencyProcessorImpl: DependencyProcessor {
     private let bundlePath: String?
 
     init(xcode: URL, product: URL, source: URL, intermediate: URL, bundle: URL?) {
-        xcodePath = xcode.path
-        productPath = product.path
-        sourcePath = source.path
-        intermediatePath = intermediate.path
-        bundlePath = bundle?.path
+        xcodePath = xcode.path.dirPath()
+        productPath = product.path.dirPath()
+        sourcePath = source.path.dirPath()
+        intermediatePath = intermediate.path.dirPath()
+        bundlePath = bundle?.path.dirPath()
     }
 
     func process(_ files: [URL]) -> [Dependency] {
@@ -72,7 +72,7 @@ class DependencyProcessorImpl: DependencyProcessor {
 
     private func classify(_ files: [URL]) -> [Dependency] {
         return files.map { file -> Dependency in
-            let filePath = file.path
+            let filePath = file.resolvingSymlinksInPath().path
             if filePath.hasPrefix(xcodePath) {
                 return Dependency(url: file, type: .xcode)
             } else if filePath.hasPrefix(intermediatePath) {
@@ -109,5 +109,11 @@ class DependencyProcessorImpl: DependencyProcessor {
         //   because in case of a hit, these will be taken from the artifact
         let irrelevantDependenciesType: [Dependency.Kind] = [.xcode, .intermediate, .ownProduct]
         return !irrelevantDependenciesType.contains(dependency.type)
+    }
+}
+
+fileprivate extension String {
+    func dirPath() -> String {
+        hasSuffix("/") ? self : appending("/")
     }
 }


### PR DESCRIPTION
**First fix:**

Before:

- If we have some module named `Name` that depend on `NameCommon`, all artifacts from `NameCommon` are filtered out as if they were own artifacts

What was done:

- Appended `/` symbol to the end of all paths for `DependencyProcessorImpl`

Now:

- `Name` and `NameCommon` artifacts do not interfere each other.


**Second fix:**

Before:

- On archiving, all compiled artifacts of own target, like `.modulemap` and `Name-Swift.h` were not filtered out in `DependencyProcessorImpl`

What was done:

- According to [Apple Documentation](https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html), `TARGET_BUILD_DIR` and `BUILT_PRODUCTS_DIR`, that is used by `DependencyProcessorImpl`, depend on several cases. Generally, they are the same for building. But on archive, they are different, and `DependencyProcessor` uses `TARGET_BUILD_DIR` to determine ownership of artifacts. But Xcode mostly operates with `BUILT_PRODUCTS_DIR` to list all dependencies. And, by the way, `BUILT_PRODUCTS_DIR` is just a symlink to `TARGET_BUILD_DIR`. So I added resolving symlinks in `DependencyProcessorImpl`. 
- Other possibility: use `BUILT_PRODUCTS_DIR` in `DependencyProcessorImpl` instead, but I'm not sure why it is `TARGET_BUILD_DIR` now. So I decided just to resolve symlinks

Now:

- All compiled own module artifacts are filtered out by `DependencyProcessorImpl`. 
