### PR TITLE
Make DependenciesRemapper throwable

### DIFF
--- a/Sources/XCRemoteCache/Commands/Postbuild/Postbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/Postbuild.swift
@@ -153,7 +153,7 @@ class Postbuild {
         // Replace all local paths to the generic ones (e.g. $SRCROOT)
         let remappers = [remapper] + creatorPlugins.compactMap(\.customPathsRemapper)
         let remapper = DependenciesRemapperComposite(remappers)
-        let abstractFingerprintFiles = remapper.replace(localPaths: dependencies.map(\.path))
+        let abstractFingerprintFiles = try remapper.replace(localPaths: dependencies.map(\.path))
         // TODO: use `inputs` read by dependenciesReader
         var meta = MainArtifactMeta(
             dependencies: abstractFingerprintFiles,

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -153,7 +153,7 @@ public class XCPostbuild {
                 mode: .bestEffort,
                 fileReader: fileManager
             )
-            let overlayRemapper = try OverlayDependenciesRemapper(
+            let overlayRemapper = OverlayDependenciesRemapper(
                 overlayReader: overlayReader
             )
             let pathRemapper = DependenciesRemapperComposite([overlayRemapper, envsRemapper])

--- a/Sources/XCRemoteCache/Commands/Prebuild/Prebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/Prebuild.swift
@@ -63,7 +63,7 @@ class Prebuild {
         do {
             let metaData = try networkClient.fetch(.meta(commit: commit))
             let meta = try metaReader.read(data: metaData)
-            let localDependencies = remapper.replace(genericPaths: meta.dependencies).map(URL.init(fileURLWithPath:))
+            let localDependencies = try remapper.replace(genericPaths: meta.dependencies).map(URL.init(fileURLWithPath:))
             let localFingerprint = try generateFingerprint(for: localDependencies)
             if localFingerprint.raw != meta.rawFingerprint {
                 if context.forceCached {

--- a/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
@@ -127,7 +127,7 @@ public class XCPrebuild {
                 mode: .bestEffort,
                 fileReader: fileManager
             )
-            let overlayRemapper = try OverlayDependenciesRemapper(
+            let overlayRemapper = OverlayDependenciesRemapper(
                 overlayReader: overlayReader
             )
             let pathRemapper = DependenciesRemapperComposite([overlayRemapper, envsRemapper])

--- a/Sources/XCRemoteCache/Dependencies/DependenciesRemapper.swift
+++ b/Sources/XCRemoteCache/Dependencies/DependenciesRemapper.swift
@@ -22,9 +22,9 @@ import Foundation
 /// Replaces paths formats between generic (placeholders-based) and local
 protocol DependenciesRemapper {
     /// Replaces all generic paths (with placeholders) to a local paths
-    func replace(genericPaths: [String]) -> [String]
+    func replace(genericPaths: [String]) throws -> [String]
     /// Replaces all local paths to the generic dependencies paths
-    func replace(localPaths: [String]) -> [String]
+    func replace(localPaths: [String]) throws -> [String]
 }
 
 class DependenciesRemapperComposite: DependenciesRemapper {
@@ -34,15 +34,15 @@ class DependenciesRemapperComposite: DependenciesRemapper {
         self.remappers = remappers
     }
 
-    func replace(genericPaths: [String]) -> [String] {
-        remappers.reversed().reduce(genericPaths) { prev, mapper in
-            mapper.replace(genericPaths: prev)
+    func replace(genericPaths: [String]) throws -> [String] {
+        try remappers.reversed().reduce(genericPaths) { prev, mapper in
+            try mapper.replace(genericPaths: prev)
         }
     }
 
-    func replace(localPaths: [String]) -> [String] {
-        remappers.reduce(localPaths) { prev, mapper in
-            mapper.replace(localPaths: prev)
+    func replace(localPaths: [String]) throws -> [String] {
+        try remappers.reduce(localPaths) { prev, mapper in
+            try mapper.replace(localPaths: prev)
         }
     }
 }
@@ -59,7 +59,7 @@ final class StringDependenciesRemapper: DependenciesRemapper {
         self.mappings = mappings
     }
 
-    func replace(genericPaths: [String]) -> [String] {
+    func replace(genericPaths: [String]) throws -> [String] {
         return genericPaths.map { path in
             let localPath = mappings.reversed().reduce(path) { prevPath, mapping in
                 prevPath.replacingOccurrences(of: mapping.generic, with: mapping.local)
@@ -68,7 +68,7 @@ final class StringDependenciesRemapper: DependenciesRemapper {
         }
     }
 
-    func replace(localPaths: [String]) -> [String] {
+    func replace(localPaths: [String]) throws -> [String] {
         return localPaths.map { path in
             let result = mappings.reduce(path) { prevPath, mapping in
                 prevPath.replacingOccurrences(of: mapping.local, with: mapping.generic)

--- a/Sources/XCRemoteCache/Dependencies/OverlayDependenciesRemapper.swift
+++ b/Sources/XCRemoteCache/Dependencies/OverlayDependenciesRemapper.swift
@@ -20,20 +20,32 @@
 import Foundation
 
 /// File paths remapper according the virtual file system mappings
-/// Warning: this class is not thread safe
+/// - Warning: this class is not thread safe
 class OverlayDependenciesRemapper: DependenciesRemapper {
-    private var mappings: [OverlayMapping]
+    private let overlayReader: OverlayReader
+    private var mappings: [OverlayMapping]?
 
-    init(overlayReader: OverlayReader) throws {
-        mappings = try overlayReader.provideMappings()
+    init(overlayReader: OverlayReader) {
+        self.overlayReader = overlayReader
+    }
+
+    /// Lazily Reads mappings from a file
+    /// - Warning: this file is not thread safe
+    private func getMappings() throws -> [OverlayMapping] {
+        guard let mappings = mappings else {
+            let mappings = try overlayReader.provideMappings()
+            self.mappings = mappings
+            return mappings
+        }
+        return mappings
     }
 
     private func mapPath(
         _ path: String,
         source: KeyPath<OverlayMapping,URL>,
         destination: KeyPath<OverlayMapping,URL>
-    ) -> String {
-        guard let mapping = mappings.first(where: { $0[keyPath: source].path == path }) else {
+    ) throws -> String {
+        guard let mapping = try getMappings().first(where: { $0[keyPath: source].path == path }) else {
             // TODO: support partial mappings, where a directory path can be replaced with some other directory
             // no direct mapping found
             return path
@@ -41,15 +53,15 @@ class OverlayDependenciesRemapper: DependenciesRemapper {
         return mapping[keyPath: destination].path
     }
 
-    func replace(genericPaths: [String]) -> [String] {
-        Set(genericPaths.map {
-            mapPath($0, source: \.virtual, destination: \.local)
+    func replace(genericPaths: [String]) throws -> [String] {
+        try Set(genericPaths.map {
+            try mapPath($0, source: \.virtual, destination: \.local)
         }).sorted()
     }
 
-    func replace(localPaths: [String]) -> [String] {
-        Set(localPaths.map {
-            mapPath($0, source: \.local, destination: \.virtual)
+    func replace(localPaths: [String]) throws -> [String] {
+        try Set(localPaths.map {
+            try mapPath($0, source: \.local, destination: \.virtual)
         }).sorted()
     }
 }

--- a/Sources/XCRemoteCache/Dependencies/OverlayDependenciesRemapper.swift
+++ b/Sources/XCRemoteCache/Dependencies/OverlayDependenciesRemapper.swift
@@ -30,7 +30,7 @@ class OverlayDependenciesRemapper: DependenciesRemapper {
     }
 
     /// Lazily Reads mappings from a file
-    /// - Warning: this file is not thread safe
+    /// - Warning: this function is not thread safe
     private func getMappings() throws -> [OverlayMapping] {
         guard let mappings = mappings else {
             let mappings = try overlayReader.provideMappings()

--- a/Tests/XCRemoteCacheTests/Dependencies/DependenciesRemapperCompositeTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/DependenciesRemapperCompositeTests.swift
@@ -29,52 +29,52 @@ class DependenciesRemapperCompositeTests: XCTestCase {
         StringDependenciesRemapper.Mapping(generic: "$(PWD)", local: "/pwd"),
     ]
 
-    func testNoRemappersIsTransparent() {
+    func testNoRemappersIsTransparent() throws {
         let remapper = DependenciesRemapperComposite([])
 
-        let genericPath = remapper.replace(localPaths: ["/tmp/root/some.swift"])
+        let genericPath = try remapper.replace(localPaths: ["/tmp/root/some.swift"])
 
         XCTAssertEqual(genericPath, ["/tmp/root/some.swift"])
     }
 
-    func testOneRemapperReplacesLocalPaths() {
+    func testOneRemapperReplacesLocalPaths() throws {
         let remapper = DependenciesRemapperComposite([
             StringDependenciesRemapper(mappings: mappings1),
         ])
 
-        let genericPath = remapper.replace(localPaths: ["/tmp/root/some.swift"])
+        let genericPath = try remapper.replace(localPaths: ["/tmp/root/some.swift"])
 
         XCTAssertEqual(genericPath, ["$(SRC_ROOT)/some.swift"])
     }
 
-    func testOneRemapperReplacesGenericPaths() {
+    func testOneRemapperReplacesGenericPaths() throws {
         let remapper = DependenciesRemapperComposite([
             StringDependenciesRemapper(mappings: mappings1),
         ])
 
-        let localPath = remapper.replace(genericPaths: ["$(SRC_ROOT)/some.swift"])
+        let localPath = try remapper.replace(genericPaths: ["$(SRC_ROOT)/some.swift"])
 
         XCTAssertEqual(localPath, ["/tmp/root/some.swift"])
     }
 
-    func testTwoRemappersReplacesLocalPaths() {
+    func testTwoRemappersReplacesLocalPaths() throws {
         let remapper = DependenciesRemapperComposite([
             StringDependenciesRemapper(mappings: mappings1),
             StringDependenciesRemapper(mappings: mappings2),
         ])
 
-        let genericPath = remapper.replace(localPaths: ["/tmp/root/some.swift", "/pwd/other.swift"])
+        let genericPath = try remapper.replace(localPaths: ["/tmp/root/some.swift", "/pwd/other.swift"])
 
         XCTAssertEqual(genericPath, ["$(SRC_ROOT)/some.swift", "$(PWD)/other.swift"])
     }
 
-    func testOneRemappersReplacesGenericPaths() {
+    func testOneRemappersReplacesGenericPaths() throws {
         let remapper = DependenciesRemapperComposite([
             StringDependenciesRemapper(mappings: mappings1),
             StringDependenciesRemapper(mappings: mappings2),
         ])
 
-        let localPath = remapper.replace(genericPaths: ["$(SRC_ROOT)/some.swift", "$(PWD)/other.swift"])
+        let localPath = try remapper.replace(genericPaths: ["$(SRC_ROOT)/some.swift", "$(PWD)/other.swift"])
 
         XCTAssertEqual(localPath, ["/tmp/root/some.swift", "/pwd/other.swift"])
     }
@@ -86,7 +86,7 @@ class DependenciesRemapperCompositeTests: XCTestCase {
         ])
         let localPaths = ["/root/specific/file"]
 
-        let genericPaths = remapper.replace(localPaths: localPaths)
+        let genericPaths = try remapper.replace(localPaths: localPaths)
 
         XCTAssertEqual(genericPaths, ["$(SPECIFIC)/file"])
     }
@@ -98,7 +98,7 @@ class DependenciesRemapperCompositeTests: XCTestCase {
         ])
         let genericPaths = ["$(SPECIFIC)/file"]
 
-        let localPaths = remapper.replace(genericPaths: genericPaths)
+        let localPaths = try remapper.replace(genericPaths: genericPaths)
 
         XCTAssertEqual(localPaths, ["/root/specific/file"])
     }
@@ -110,8 +110,8 @@ class DependenciesRemapperCompositeTests: XCTestCase {
         ])
         let localPaths = ["/root/specific/file"]
 
-        let genericPaths = remapper.replace(localPaths: localPaths)
-        let remappedLocalPaths = remapper.replace(genericPaths: genericPaths)
+        let genericPaths = try remapper.replace(localPaths: localPaths)
+        let remappedLocalPaths = try remapper.replace(genericPaths: genericPaths)
 
         XCTAssertEqual(localPaths, remappedLocalPaths)
     }

--- a/Tests/XCRemoteCacheTests/Dependencies/OverlayDependenciesRemapperTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/OverlayDependenciesRemapperTests.swift
@@ -26,40 +26,46 @@ class OverlayDependenciesRemapperTests: XCTestCase {
     )
 
     func testMappingFromLocalToGeneric() throws {
-        let reader = try OverlayDependenciesRemapper(
-            overlayReader: overlayReader
-        )
+        let remapper = OverlayDependenciesRemapper(overlayReader: overlayReader)
 
-        let dependencies = reader.replace(localPaths: ["/Intermediate/Some/file.h"])
+        let dependencies = try remapper.replace(localPaths: ["/Intermediate/Some/file.h"])
         XCTAssertEqual(dependencies, ["/file.h"])
     }
 
     func testMappingFromGenericToLocal() throws {
-        let reader = try OverlayDependenciesRemapper(
-            overlayReader: overlayReader
-        )
+        let remapper = OverlayDependenciesRemapper(overlayReader: overlayReader)
 
-        let dependencies = reader.replace(genericPaths: ["/file.h"])
+
+        let dependencies = try remapper.replace(genericPaths: ["/file.h"])
         XCTAssertEqual(dependencies, ["/Intermediate/Some/file.h"])
     }
 
     func testGenericDependenciesAreMerged() throws {
+        let remapper = OverlayDependenciesRemapper(overlayReader: overlayReader)
 
-        let reader = try OverlayDependenciesRemapper(
-            overlayReader: overlayReader
-        )
 
-        let dependencies = reader.replace(localPaths: ["/Intermediate/Some/file.h", "/file.h"])
+        let dependencies = try remapper.replace(localPaths: ["/Intermediate/Some/file.h", "/file.h"])
         XCTAssertEqual(dependencies, ["/file.h"])
     }
 
     func testLocalDependenciesAreMerged() throws {
-        let reader = try OverlayDependenciesRemapper(
-            overlayReader: overlayReader
-        )
+        let remapper = OverlayDependenciesRemapper(overlayReader: overlayReader)
 
-        let dependencies = reader.replace(genericPaths: ["/Intermediate/Some/file.h", "/file.h"])
+
+        let dependencies = try remapper.replace(genericPaths: ["/Intermediate/Some/file.h", "/file.h"])
         XCTAssertEqual(dependencies, ["/Intermediate/Some/file.h"])
+    }
+
+    func testMappingsAreReadOnce() throws {
+        let remapper = OverlayDependenciesRemapper(overlayReader: overlayReader)
+
+        let firstDependencies = try remapper.replace(localPaths: ["/Intermediate/Some/file.h"])
+        // Update mappings in-fly to verify the previous value is cached in a remapper
+        overlayReader.mappings = []
+        let secondDependencies = try remapper.replace(localPaths: ["/Intermediate/Some/file.h"])
+
+        XCTAssertEqual(firstDependencies, ["/file.h"])
+        XCTAssertEqual(secondDependencies, ["/file.h"])
     }
 }
 

--- a/Tests/XCRemoteCacheTests/Dependencies/StringDependenciesRemapperFactoryTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/StringDependenciesRemapperFactoryTests.swift
@@ -34,7 +34,7 @@ class StringDependenciesRemapperFactoryTests: XCTestCase {
             customMappings: [:]
         )
 
-        let localPaths = remapper.replace(genericPaths: ["$(SRC_ROOT)/some.swift"])
+        let localPaths = try remapper.replace(genericPaths: ["$(SRC_ROOT)/some.swift"])
         XCTAssertEqual(localPaths, ["/tmp/root/some.swift"])
     }
 
@@ -55,7 +55,7 @@ class StringDependenciesRemapperFactoryTests: XCTestCase {
             customMappings: ["TMP": "/tmp"]
         )
 
-        let genericPaths = remapper.replace(localPaths: ["/some/repoFile.swift", "/tmp/externalFile.swift"])
+        let genericPaths = try remapper.replace(localPaths: ["/some/repoFile.swift", "/tmp/externalFile.swift"])
         XCTAssertEqual(genericPaths, ["$(PWD)/repoFile.swift", "$(TMP)/externalFile.swift"])
     }
 

--- a/Tests/XCRemoteCacheTests/Dependencies/StringDependenciesRemapperTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/StringDependenciesRemapperTests.swift
@@ -30,34 +30,34 @@ class StringDependenciesRemapperTests: XCTestCase {
         remapper = StringDependenciesRemapper(mappings: mappings)
     }
 
-    func testMappingSingleGenericPathReplacesWithLocalPath() {
-        let localPaths = remapper.replace(genericPaths: ["$(SRC_ROOT)/some.swift"])
+    func testMappingSingleGenericPathReplacesWithLocalPath() throws {
+        let localPaths = try remapper.replace(genericPaths: ["$(SRC_ROOT)/some.swift"])
 
         XCTAssertEqual(localPaths, ["/tmp/root/some.swift"])
     }
 
-    func testRewritingSingleLocalPathReplacesWithGenericPath() {
-        let genericPaths = remapper.replace(localPaths: ["/tmp/root/some.swift"])
+    func testRewritingSingleLocalPathReplacesWithGenericPath() throws {
+        let genericPaths = try remapper.replace(localPaths: ["/tmp/root/some.swift"])
 
         XCTAssertEqual(genericPaths, ["$(SRC_ROOT)/some.swift"])
     }
 
-    func testRewritingLocalToGenericAndLocalIsIdentical() {
+    func testRewritingLocalToGenericAndLocalIsIdentical() throws {
         let inputLocalPaths = ["/tmp/root/some.swift"]
 
-        let genericPaths = remapper.replace(localPaths: inputLocalPaths)
-        let localPaths = remapper.replace(genericPaths: genericPaths)
+        let genericPaths = try remapper.replace(localPaths: inputLocalPaths)
+        let localPaths = try remapper.replace(genericPaths: genericPaths)
 
         XCTAssertEqual(localPaths, inputLocalPaths)
     }
 
-    func testRewritingUnrelatedDirReturnsInputPath() {
-        let genericPaths = remapper.replace(localPaths: ["/other/some.swift"])
+    func testRewritingUnrelatedDirReturnsInputPath() throws {
+        let genericPaths = try remapper.replace(localPaths: ["/other/some.swift"])
 
         XCTAssertEqual(genericPaths, ["/other/some.swift"])
     }
 
-    func testMultipleMatchesTakeTheFirstMapping() {
+    func testMultipleMatchesTakeTheFirstMapping() throws {
         let mappings: [StringDependenciesRemapper.Mapping] = [
             .init(generic: "$(SRC_ROOT)", local: "/tmp/root"),
             .init(generic: "$(PWD)", local: "/tmp"),
@@ -65,12 +65,12 @@ class StringDependenciesRemapperTests: XCTestCase {
         remapper = StringDependenciesRemapper(mappings: mappings)
 
 
-        let genericPaths = remapper.replace(localPaths: ["/tmp/root/some.swift", "/tmp/extra.swift"])
+        let genericPaths = try remapper.replace(localPaths: ["/tmp/root/some.swift", "/tmp/extra.swift"])
 
         XCTAssertEqual(genericPaths, ["$(SRC_ROOT)/some.swift", "$(PWD)/extra.swift"])
     }
 
-    func testMappingsLocalPathsIsDoneInOrder() {
+    func testMappingsLocalPathsIsDoneInOrder() throws {
         let mappings: [StringDependenciesRemapper.Mapping] = [
             .init(generic: "$(TMP)", local: "/tmp"),
             .init(generic: "$(ROOT)", local: "$(TMP)/root"),
@@ -78,12 +78,12 @@ class StringDependenciesRemapperTests: XCTestCase {
         remapper = StringDependenciesRemapper(mappings: mappings)
 
 
-        let genericPaths = remapper.replace(localPaths: ["/tmp/root/some.swift"])
+        let genericPaths = try remapper.replace(localPaths: ["/tmp/root/some.swift"])
 
         XCTAssertEqual(genericPaths, ["$(ROOT)/some.swift"])
     }
 
-    func testMappingsGenericPathsIsDoneInReversedOrder() {
+    func testMappingsGenericPathsIsDoneInReversedOrder() throws {
         let mappings: [StringDependenciesRemapper.Mapping] = [
             .init(generic: "$(TMP)", local: "/tmp"),
             .init(generic: "$(ROOT)", local: "$(TMP)/root"),
@@ -91,7 +91,7 @@ class StringDependenciesRemapperTests: XCTestCase {
         remapper = StringDependenciesRemapper(mappings: mappings)
 
 
-        let localPaths = remapper.replace(genericPaths: ["$(ROOT)/some.swift"])
+        let localPaths = try remapper.replace(genericPaths: ["$(ROOT)/some.swift"])
 
         XCTAssertEqual(localPaths, ["/tmp/root/some.swift"])
     }

--- a/Tests/XCRemoteCacheTests/TestDoubles/OverlayReaderFake.swift
+++ b/Tests/XCRemoteCacheTests/TestDoubles/OverlayReaderFake.swift
@@ -21,7 +21,8 @@ import Foundation
 @testable import XCRemoteCache
 
 class OverlayReaderFake: OverlayReader {
-    private let mappings: [OverlayMapping]
+    var mappings: [OverlayMapping]
+    
     init(mappings: [OverlayMapping]) {
         self.mappings = mappings
     }


### PR DESCRIPTION
#71 follow-up.

Makes `DependenciesRemapper` methods throwable, so `OverlayDependenciesRemapper` initializer is non-throwing. 
The change does not introduce any behavior changes.