### PR TITLE
Rename prebuild and postbuild phases, adjust prebuild position

### DIFF
--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
@@ -145,7 +145,7 @@ module CocoapodsXCRemoteCacheModifier
           ]
           prebuild_script.dependency_file = "$(TARGET_TEMP_DIR)/prebuild.d"
 
-          # Move prebuild (last element) to the first position (to make it real 'prebuild')
+          # Move prebuild (last element) to the position before compile sources phase (to make it real 'prebuild')
           compile_phase_index = target.build_phases.index(target.source_build_phase)
           target.build_phases.insert(compile_phase_index, target.build_phases.delete(prebuild_script))
         elsif mode == 'producer' || mode == 'producer-fast'


### PR DESCRIPTION
I decided to add target name to all pre- and postbuild phases for better search through build logs for debugging purposes

I also moved prebuild script from "top" position to "before compile". The main point is because there are, generally, many scripts in podspecs, like swiftlint and swiftgen (especially).

And if [XCRC] prebuild phase comes before swiftgen, it leads to cycle dependency error on second build. But if we put [XCRC] prebuild phase before compile sources, and after swiftgen, everything works fine.

And, another reason: both linters and generator scripts can modify files, and XCRC should handle it and turn off caches.