### PR TITLE
[Integrate] Place xcprebuild script right before compilation

### DIFF
--- a/Sources/XCRemoteCache/Commands/Prepare/Integrate/XcodeProjIntegrate.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/Integrate/XcodeProjIntegrate.swift
@@ -227,11 +227,11 @@ struct XcodeProjIntegrate: Integrate {
         let previousRCPhases = target.buildPhases.filter(isRCPhase)
         target.buildPhases.removeAll(where: previousRCPhases.contains)
 
-        if target.buildPhases.map(\.buildPhase).contains(.sources) {
+        if let sourceIndex = target.buildPhases.map(\.buildPhase).firstIndex(of: .sources) {
             // add (pre|post)build phases only when a target has some compilation steps
             // otherwise they make no sense (nothing to store in an artifact)
             pbxproj.add(object: prebuildPhase)
-            target.buildPhases.insert(prebuildPhase, at: 0)
+            target.buildPhases.insert(prebuildPhase, at: sourceIndex)
             pbxproj.add(object: postbuildPhase)
             target.buildPhases.append(postbuildPhase)
         }


### PR DESCRIPTION
Adds the prebuild script right before compilation. Some extra steps (like swiftlint) should be invoked **before** `xcprebuild` as they can potentially modify the source code.

#### Before:
<img width="272" alt="Screenshot 2022-02-09 at 17 57 37" src="https://user-images.githubusercontent.com/9629417/153250624-f4877b4a-1df1-4b67-9dfc-0cbd2b2163ca.png">

#### After:
<img width="268" alt="Screenshot 2022-02-09 at 17 56 26" src="https://user-images.githubusercontent.com/9629417/153250593-5019ae29-1626-4b88-9130-79630e384181.png">


Aligns with CocoaPods' change applied in #74.

