### PR TITLE
Prepare xccc before starting CCWrapper tests

### DIFF
--- a/Tests/XCRemoteCacheTests/Commands/XCCCTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/XCCCTests.swift
@@ -28,7 +28,7 @@ class TemplateBasedCCWrapperBuilderTests: FileXCTestCase {
     private static let history = "history.compile"
     private static let prebuild = "prebuild.d"
     private static let commitSha = "321"
-    private static let timeout = 10.0
+    private static let timeout = 5.0
 
     static let xccc: URL = {
         let fileManager = FileManager.default

--- a/Tests/XCRemoteCacheTests/Commands/XCCCTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/XCCCTests.swift
@@ -60,6 +60,13 @@ class TemplateBasedCCWrapperBuilderTests: FileXCTestCase {
     private var prebuildFile: URL!
     private var arguments: [String]!
 
+    override class func setUp() {
+        // Prepare(compile) xccc and invoke it to get rid of a constant delay that happens if the xccc is invoked
+        // for a first time. For some (unknown) reasons, `shellCall` hangs for ~5s (only once).
+        _ = xccc
+        try? shellCall(xccc.path)
+    }
+
     override func setUpWithError() throws {
         try super.setUpWithError()
 


### PR DESCRIPTION
Our `TemplateBasedCCWrapperBuilderTests` unit tests sometimes get a timeout like:
```
/Users/runner/work/XCRemoteCache/XCRemoteCache/Tests/XCRemoteCacheTests/Commands/XCCCTests.swift:133: error: -[XCRemoteCacheTests.TemplateBasedCCWrapperBuilderTests testAddsExclusivlyToCompileHistory] : Asynchronous wait failed: Exceeded timeout of 10 seconds, with unfulfilled expectations: "Started xccc".
```
[example](https://github.com/spotify/XCRemoteCache/runs/5129130666?check_suite_focus=true#step:5:1270)

For some reason, the very first execution of a freshly compiled wrapper file (`xccc`) takes ~5s (on my machine) and on CI it may take more time. This PR compiles `xccc` before the first `TemplateBasedCCWrapperBuilderTests` test so our test cases can have smaller timeouts (the delay of the compilation + first invocation) does not contribute to the total case duration.