### PR TITLE
Do not fail prebuild/postbuild for invalid vfs overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ _Note that for the `producer` mode, the prebuild build phase and `xccc`, `xcld`,
 | `aws_service` | Service for AWS V4 Signature Authorization. E.g. `storage`. | `""` | ⬜️ |
 | `out_of_band_mappings` | A dictionary of files path remapping that should be applied to make it absolute path agnostic on a list of dependencies. Useful if a project refers files out of repo root, either compilation files or precompiled dependencies. Keys represent generic replacement and values are substrings that should be replaced. Example: for mapping `["COOL_LIBRARY": "/CoolLibrary"]` `/CoolLibrary/main.swift`will be represented as `$(COOL_LIBRARY)/main.swift`). Warning: remapping order is not-deterministic so avoid remappings with multiple matchings. | `[:]` | ⬜️ |
 | `disable_certificate_verification` | A Boolean value that opts-in SSL certificate validation is disabled | `false` | ⬜️ |
+| `disable_vfs_overlay` | A feature flag to disable virtual file system overlay support (temporary) | `false` | ⬜️ |
 
 ## Backend cache server
 

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -131,6 +131,8 @@ public struct XCRemoteCacheConfig: Encodable {
     var outOfBandMappings: [String: String] = [:]
     /// If true, SSL certificate validation is disabled
     var disableCertificateVerification: Bool = false
+    /// A feature flag to disable virtual file system overlay support (temporary)
+    var disableVFSOverlay: Bool = false
 }
 
 extension XCRemoteCacheConfig {
@@ -183,6 +185,7 @@ extension XCRemoteCacheConfig {
         merge.AWSService = scheme.AWSService ?? AWSService
         merge.outOfBandMappings = scheme.outOfBandMappings ?? outOfBandMappings
         merge.disableCertificateVerification = scheme.disableCertificateVerification ?? disableCertificateVerification
+        merge.disableVFSOverlay = scheme.disableVFSOverlay ?? disableVFSOverlay
         return merge
     }
 
@@ -244,6 +247,7 @@ struct ConfigFileScheme: Decodable {
     let AWSService: String?
     let outOfBandMappings: [String: String]?
     let disableCertificateVerification: Bool?
+    let disableVFSOverlay: Bool?
 
     // Yams library doesn't support encoding strategy, see https://github.com/jpsim/Yams/issues/84
     enum CodingKeys: String, CodingKey {
@@ -288,6 +292,7 @@ struct ConfigFileScheme: Decodable {
         case AWSService = "aws_service"
         case outOfBandMappings = "out_of_band_mappings"
         case disableCertificateVerification = "disable_certificate_verification"
+        case disableVFSOverlay = "disable_vfs_overlay"
     }
 }
 

--- a/Tests/XCRemoteCacheTests/Dependencies/OverlayReaderTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/OverlayReaderTests.swift
@@ -20,7 +20,7 @@
 @testable import XCRemoteCache
 import XCTest
 
-class JsonOverlayReaderTests: XCTestCase {
+class JsonOverlayReaderTests: FileXCTestCase {
     private static let resourcesSubdirectory = "TestData/Dependencies/JsonOverlayReaderTests"
 
     func testParsingWithSuccess() throws {
@@ -57,6 +57,25 @@ class JsonOverlayReaderTests: XCTestCase {
         let mappings = try reader.provideMappings()
 
         XCTAssertEqual(mappings, [])
+    }
+
+    func testInvalidJsonDoesntThrowForBestEffortMode() throws {
+        let workingDir = try prepareTempDir()
+        let file = workingDir.appendingPathExtension("overlay.json")
+        try fileManager.spt_createEmptyFile(file)
+        let reader = JsonOverlayReader(file, mode: .bestEffort, fileReader: fileManager)
+        let mappings = try reader.provideMappings()
+
+        XCTAssertEqual(mappings, [])
+    }
+
+    func testInvalidJsonThrowsForStrictMode() throws {
+        let workingDir = try prepareTempDir()
+        let file = workingDir.appendingPathExtension("overlay.json")
+        try fileManager.spt_createEmptyFile(file)
+        let reader = JsonOverlayReader(file, mode: .strict, fileReader: fileManager)
+
+        XCTAssertThrowsError(try reader.provideMappings())
     }
 
     private func pathForTestData(name: String) throws -> URL {


### PR DESCRIPTION
#80 reports that VFS overlay support leads to a poor cache hit. It might be caused by a more advanced vfs overlay structure, not supported (yet) by XCRemoteCache.

This PR:
* skips the overlay file if it has an unknown format (we always use best-effort mode)
* adds a temporary flag to disable VFS from .rcinfo