### PR TITLE
Do not change dependencies order when remapping overlay

### DIFF
--- a/Sources/XCRemoteCache/Dependencies/OverlayDependenciesRemapper.swift
+++ b/Sources/XCRemoteCache/Dependencies/OverlayDependenciesRemapper.swift
@@ -54,14 +54,14 @@ class OverlayDependenciesRemapper: DependenciesRemapper {
     }
 
     func replace(genericPaths: [String]) throws -> [String] {
-        try Set(genericPaths.map {
+        try genericPaths.map {
             try mapPath($0, source: \.virtual, destination: \.local)
-        }).sorted()
+        }
     }
 
     func replace(localPaths: [String]) throws -> [String] {
-        try Set(localPaths.map {
+        try localPaths.map {
             try mapPath($0, source: \.local, destination: \.virtual)
-        }).sorted()
+        }
     }
 }

--- a/Tests/XCRemoteCacheTests/Dependencies/OverlayDependenciesRemapperTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/OverlayDependenciesRemapperTests.swift
@@ -40,20 +40,20 @@ class OverlayDependenciesRemapperTests: XCTestCase {
         XCTAssertEqual(dependencies, ["/Intermediate/Some/file.h"])
     }
 
-    func testGenericDependenciesAreMerged() throws {
+    func testGenericDependenciesAreNotMerged() throws {
         let remapper = OverlayDependenciesRemapper(overlayReader: overlayReader)
 
 
         let dependencies = try remapper.replace(localPaths: ["/Intermediate/Some/file.h", "/file.h"])
-        XCTAssertEqual(dependencies, ["/file.h"])
+        XCTAssertEqual(dependencies, ["/file.h", "/file.h"])
     }
 
-    func testLocalDependenciesAreMerged() throws {
+    func testLocalDependenciesAreNotMerged() throws {
         let remapper = OverlayDependenciesRemapper(overlayReader: overlayReader)
 
 
         let dependencies = try remapper.replace(genericPaths: ["/Intermediate/Some/file.h", "/file.h"])
-        XCTAssertEqual(dependencies, ["/Intermediate/Some/file.h"])
+        XCTAssertEqual(dependencies, ["/Intermediate/Some/file.h", "/Intermediate/Some/file.h"])
     }
 
     func testMappingsAreReadOnce() throws {


### PR DESCRIPTION
Do not sort the dependencies list in `OverlayDependenciesRemapper`. 

#71 introduced a remapper that reads virtual file system overlay file (vfsoverlay) and based on that, computes a fingerprint based on disk files that the vfs defines.

It contained an optimization that gets rid of all duplicated dependencies (if vfsoverlay defined a mapping that remaps a path to a disk file path that is already in a dependency list). **Implementation detail: it was implemented as the simplest `Set`+sorting.**  

Even this makes sense for a producer side (the meta json file could be smaller), it has a damaging result on the consumer side. If a list of files is reordered on a consumer side (comparing the order that the producer mode observed), the file fingerprint will not match.
With hindsight, I think it was a premature optimization and the simplest solution is to just map every single dependency in order both for `consumer` and `producer` modes.

Fixes #84 and #80.