### PR TITLE
Customize rewritting dependency paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ _Note that for the `producer` mode, the prebuild build phase and `xccc`, `xcld`,
 | `out_of_band_mappings` | A dictionary of files path remapping that should be applied to make it absolute path agnostic on a list of dependencies. Useful if a project refers files out of repo root, either compilation files or precompiled dependencies. Keys represent generic replacement and values are substrings that should be replaced. Example: for mapping `["COOL_LIBRARY": "/CoolLibrary"]` `/CoolLibrary/main.swift`will be represented as `$(COOL_LIBRARY)/main.swift`). Warning: remapping order is not-deterministic so avoid remappings with multiple matchings. | `[:]` | ⬜️ |
 | `disable_certificate_verification` | A Boolean value that opts-in SSL certificate validation is disabled | `false` | ⬜️ |
 | `disable_vfs_overlay` | A feature flag to disable virtual file system overlay support (temporary) | `false` | ⬜️ |
+| `custom_rewrite_envs` | A list of extra ENVs that should be used as placeholders in the dependency list. ENV rewrite process is optimistic - does nothing if an ENV is not defined in the pre/postbuild process. | `[]` | ⬜️ |
 
 ## Backend cache server
 

--- a/Sources/XCRemoteCache/Commands/Postbuild/PostbuildContext.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/PostbuildContext.swift
@@ -119,7 +119,7 @@ extension PostbuildContext {
         dSYMPath = try env.readEnv(key: "DWARF_DSYM_FOLDER_PATH")
             .appendingPathComponent(env.readEnv(key: "DWARF_DSYM_FILE_NAME"))
         builtProductsDir = try env.readEnv(key: "BUILT_PRODUCTS_DIR")
-        if let contentsFolderPath = env.readEnv(key: "CONTENTS_FOLDER_PATH") {
+        if let contentsFolderPath: String = env.readEnv(key: "CONTENTS_FOLDER_PATH") {
             bundleDir = productsDir.appendingPathComponent(contentsFolderPath)
         } else {
             bundleDir = nil

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -66,8 +66,8 @@ public class XCPostbuild {
             // Initialize dependencies
             let primaryGitBranch = GitBranch(repoLocation: config.primaryRepo, branch: config.primaryBranch)
             let gitClient = GitClientImpl(repoRoot: config.repoRoot, primary: primaryGitBranch, shell: shellGetStdout)
-            let envsRemapper = try StringDependenciesRemapperFactory().build(
-                orderKeys: DependenciesMapping.rewrittenEnvs,
+            let envsRemapper = try PathDependenciesRemapperFactory().build(
+                orderKeys: DependenciesMapping.rewrittenEnvs + config.customRewriteEnvs,
                 envs: env,
                 customMappings: config.outOfBandMappings
             )

--- a/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
@@ -115,8 +115,8 @@ public class XCPrebuild {
             )
             let client: NetworkClient = config.disableHttpCache ? networkClient : cacheNetworkClient
             let remoteNetworkClient = RemoteNetworkClientImpl(client, urlBuilder)
-            let envsRemapper = try StringDependenciesRemapperFactory().build(
-                orderKeys: DependenciesMapping.rewrittenEnvs,
+            let envsRemapper = try PathDependenciesRemapperFactory().build(
+                orderKeys: DependenciesMapping.rewrittenEnvs + config.customRewriteEnvs,
                 envs: env,
                 customMappings: config.outOfBandMappings
             )

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -133,6 +133,9 @@ public struct XCRemoteCacheConfig: Encodable {
     var disableCertificateVerification: Bool = false
     /// A feature flag to disable virtual file system overlay support (temporary)
     var disableVFSOverlay: Bool = false
+    /// A list of extra ENVs that should be used as placeholders in the dependency list.
+    /// ENV rewrite process is optimistic - does nothing if an ENV is not defined in the pre/postbuild process.
+    var customRewriteEnvs: [String] = []
 }
 
 extension XCRemoteCacheConfig {
@@ -186,6 +189,7 @@ extension XCRemoteCacheConfig {
         merge.outOfBandMappings = scheme.outOfBandMappings ?? outOfBandMappings
         merge.disableCertificateVerification = scheme.disableCertificateVerification ?? disableCertificateVerification
         merge.disableVFSOverlay = scheme.disableVFSOverlay ?? disableVFSOverlay
+        merge.customRewriteEnvs = scheme.customRewriteEnvs ?? customRewriteEnvs
         return merge
     }
 
@@ -248,6 +252,7 @@ struct ConfigFileScheme: Decodable {
     let outOfBandMappings: [String: String]?
     let disableCertificateVerification: Bool?
     let disableVFSOverlay: Bool?
+    let customRewriteEnvs: [String]?
 
     // Yams library doesn't support encoding strategy, see https://github.com/jpsim/Yams/issues/84
     enum CodingKeys: String, CodingKey {
@@ -293,6 +298,7 @@ struct ConfigFileScheme: Decodable {
         case outOfBandMappings = "out_of_band_mappings"
         case disableCertificateVerification = "disable_certificate_verification"
         case disableVFSOverlay = "disable_vfs_overlay"
+        case customRewriteEnvs = "custom_rewrite_envs"
     }
 }
 

--- a/Sources/XCRemoteCache/Utils/ENVReader.swift
+++ b/Sources/XCRemoteCache/Utils/ENVReader.swift
@@ -24,8 +24,15 @@ enum EnvironmentError: Error {
 }
 
 extension Dictionary where Key == String, Value == String {
-    func readEnv(key: String) throws -> URL {
+    func readEnv(key: String) -> URL? {
         guard let value = self[key].map(URL.init(fileURLWithPath:)) else {
+            return nil
+        }
+        return value
+    }
+
+    func readEnv(key: String) throws -> URL {
+        guard let value: URL = readEnv(key: key) else {
             throw EnvironmentError.missingEnv(key)
         }
         return value

--- a/Tests/XCRemoteCacheTests/Dependencies/PathDependenciesRemapperFactoryTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/PathDependenciesRemapperFactoryTests.swift
@@ -20,11 +20,11 @@
 @testable import XCRemoteCache
 import XCTest
 
-class StringDependenciesRemapperFactoryTests: XCTestCase {
-    private var factory: StringDependenciesRemapperFactory!
+class PathDependenciesRemapperFactoryTests: XCTestCase {
+    private var factory: PathDependenciesRemapperFactory!
 
     override func setUp() {
-        factory = StringDependenciesRemapperFactory()
+        factory = PathDependenciesRemapperFactory()
     }
 
     func testMappingsFromEnvMaps() throws {
@@ -38,8 +38,30 @@ class StringDependenciesRemapperFactoryTests: XCTestCase {
         XCTAssertEqual(localPaths, ["/tmp/root/some.swift"])
     }
 
-    func testInvalidMappingsFromEnvFails() throws {
-        XCTAssertThrowsError(
+    func testMappingsGenericWhenMappingHasParentDir() throws {
+        let remapper = try factory.build(
+            orderKeys: ["SRC_ROOT"],
+            envs: ["SRC_ROOT": "/tmp/root/extra/.."],
+            customMappings: [:]
+        )
+
+        let localPaths = try remapper.replace(genericPaths: ["$(SRC_ROOT)/some.swift"])
+        XCTAssertEqual(localPaths, ["/tmp/root/some.swift"])
+    }
+
+    func testMappingsLocalWhenMappingHasParentDir() throws {
+        let remapper = try factory.build(
+            orderKeys: ["SRC_ROOT"],
+            envs: ["SRC_ROOT": "/tmp/root/excessive/.."],
+            customMappings: [:]
+        )
+
+        let localPaths = try remapper.replace(localPaths: ["/tmp/root/some.swift"])
+        XCTAssertEqual(localPaths, ["$(SRC_ROOT)/some.swift"])
+    }
+
+    func testMissingEnvIsSkipped() throws {
+        XCTAssertNoThrow(
             try factory.build(
                 orderKeys: ["SRC_ROOT"],
                 envs: ["NO_SRC_ROOT": ""],


### PR DESCRIPTION
#69 reported that for `development_pods` some absolute dependency paths sneak into meta .json file and thus degrade the hit rate.

I looked at how CocoaPods generates development_pods project and it has a unique setup:
* `SRCROOT` is equal to `./Pods`
* All sources are references within a group that has ".." in it. 
It is a documented requirement of XCRemoteCache to always reference files within `SRCROOT`. On the other hand, CocoaPods provide `PODS_TARGET_SRCROOT`, which points (indirectly) to the development_pod src root:
```
PODS_TARGET_SRCROOT\=some_absolute_path/MovieApp/Pods/../Modules/User
```
The idea is to add `PODS_TARGET_SRCROOT` into all EVNs that could be rewritten in the dependency identification.

This PR introduces that:
* adds an extra property `custom_rewrite_envs` that allows extending `DependenciesMapping.rewrittenEnvs` (requested also in #59)
* Makes EVN replacement path-aware to eliminate ".." or "." accordingly

### How to test?
Use the sample project shared in #69: https://github.com/dwirandyh/xcremotecache-modular-example
Add into Podfile's xcremotecache configuration:
```   
 'custom_rewrite_envs' => ['PODS_TARGET_SRCROOT']
```

Verify no absolute paths in the `User` development_pod's json.