### PR TITLE
Decorate logs with a target name

### DIFF
--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -35,6 +35,7 @@ public class XCPostbuild {
         do {
             config = try XCRemoteCacheConfigReader(env: env, fileManager: fileManager).readConfiguration()
             context = try PostbuildContext(config, env: env)
+            updateProcessTag(context.targetName)
             let counterFactory: FileStatsCoordinator.CountersFactory = { file, count in
                 ExclusiveFileCounter(ExclusiveFile(file, mode: .override), countersCount: count)
             }

--- a/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
@@ -31,6 +31,7 @@ public class XCPrebuild {
         do {
             config = try XCRemoteCacheConfigReader(env: env, fileManager: fileManager).readConfiguration()
             context = try PrebuildContext(config, env: env)
+            updateProcessTag(context.targetName)
         } catch {
             // Fatal error:
             exit(1, "FATAL: Prebuild initialization failed with error: \(error)")

--- a/Sources/XCRemoteCache/Logger/Logger.swift
+++ b/Sources/XCRemoteCache/Logger/Logger.swift
@@ -22,38 +22,44 @@ import Foundation
 import os.log
 
 
+private var processTag: String = ""
+
 public func exit(_ exitCode: Int32, _ message: String) -> Never {
-    os_log("%{public}@", log: OSLog.default, type: .error, message)
+    os_log("%{public}@%{public}@", log: OSLog.default, type: .error, processTag, message)
     printError(errorMessage: message)
     exit(exitCode)
 }
 
 func defaultLog(_ message: String) {
-    os_log("%{public}@", log: OSLog.default, type: .default, message)
+    os_log("%{public}@%{public}@", log: OSLog.default, type: .default, processTag, message)
 }
 
 func errorLog(_ message: String) {
-    os_log("%{public}@", log: OSLog.default, type: .error, message)
+    os_log("%{public}@%{public}@", log: OSLog.default, type: .error, processTag, message)
 }
 
 func infoLog(_ message: String) {
-    os_log("%{public}@", log: OSLog.default, type: .info, message)
+    os_log("%{public}@%{public}@", log: OSLog.default, type: .info, processTag, message)
 }
 
 func debugLog(_ message: String) {
-    os_log("%{public}@", log: OSLog.default, type: .debug, message)
+    os_log("%{public}@%{public}@", log: OSLog.default, type: .debug, processTag, message)
 }
 
 func printError(errorMessage: String) {
-    fputs("error: \(errorMessage)\n", stderr)
+    fputs("error: \(processTag)\(errorMessage)\n", stderr)
 }
 
 func printWarning(_ message: String) {
-    print("warning: \(message)")
+    print("warning: \(processTag)\(message)")
 }
 
 /// Prints a message to the user. It shows in Xcode (if applies) or console output
 /// - Parameter message: message to print
 func printToUser(_ message: String) {
     print("[RC] \(message)")
+}
+
+func updateProcessTag(_ tag: String) {
+    processTag = "(\(tag)) "
 }


### PR DESCRIPTION
Reading logs with `log show --predicate ....` is very difficult for a project with many targets. It is hard to distinguish the target it comes from. 
This PR prefixes all log messages with `(TargetName)` in the prebuild/postbuild processes.  
If the target name is not known yet (initialization phase), the prefix is not added.

### Before

<img width="623" alt="Screenshot 2022-02-17 at 20 38 55" src="https://user-images.githubusercontent.com/9629417/154557805-72632cb2-0755-4176-a49c-f9ac8ac06c02.png">

### After

<img width="530" alt="Screenshot 2022-02-17 at 20 35 48" src="https://user-images.githubusercontent.com/9629417/154557688-981faeda-fd68-41c4-acd1-12e2f4dce05c.png">
