### PR TITLE
Bump CocoaPods plugin version

### DIFF
--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module CocoapodsXcremotecache
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end


### PR DESCRIPTION
Preparing for a release 0.3.7 that should also update the CocoaPods plugin to include: https://github.com/spotify/XCRemoteCache/pull/74