### PR TITLE
Disable local URLSession cache

### DIFF
--- a/Sources/XCRemoteCache/Network/URLSessionFactory.swift
+++ b/Sources/XCRemoteCache/Network/URLSessionFactory.swift
@@ -36,6 +36,8 @@ class DefaultURLSessionFactory: URLSessionFactory {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = config.requestCustomHeaders
         configuration.timeoutIntervalForRequest = config.timeoutResponseDataChunksInterval
+        configuration.urlCache?.memoryCapacity = 0
+        configuration.urlCache?.diskCapacity = 0
         switch config.disableCertificateVerification {
         case true:
             return URLSession(


### PR DESCRIPTION
By default, (NS)URLSession creates a local cache at `~/Library/Caches/xc{prebuild|postbuild}`. This cache is redundant as we have a proprietary cache handled by `CachedNetworkClient`.

Note: This change does not evict existing entries but does not append any new entries there. On a machine that never has never run XCRemoteCache, a cache directory will not be even created. 