### PR TITLE
Print overlay error messages to os_log only

### DIFF
--- a/Sources/XCRemoteCache/Dependencies/OverlayReader.swift
+++ b/Sources/XCRemoteCache/Dependencies/OverlayReader.swift
@@ -91,7 +91,7 @@ class JsonOverlayReader: OverlayReader {
             case .strict:
                 throw JsonOverlayReaderError.missingSourceFile(json)
             case .bestEffort:
-                printWarning("overlay mapping file \(json) doesn't exist. Skipping overlay for the best-effort mode.")
+                debugLog("overlay mapping file \(json) doesn't exist. Skipping overlay for the best-effort mode.")
                 return []
             }
         }
@@ -124,7 +124,7 @@ class JsonOverlayReader: OverlayReader {
             case .strict:
                 throw error
             case .bestEffort:
-                printWarning("Overlay reader has failed with an error \(error). Best-effort mode - skipping an overlay.")
+                errorLog("Overlay reader has failed with an error \(error). Best-effort mode - skipping an overlay.")
                 return []
             }
         }


### PR DESCRIPTION
#92 reported that `"all-product-headers.yaml doesn't exist. Skipping overlay for the best-effort mode."` is printed in Xcode and treated as a warning.  This is a minor log and I think it doesn't have to be propagated to Xcode's logs at all.

This PR switches it to the `os_log` message.