### PR TITLE
Adding quotes to the config param in the Mark script 

### DIFF
--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
@@ -180,7 +180,7 @@ module CocoapodsXCRemoteCacheModifier
             end
           end
           mark_script = existing_mark_script || target.new_shell_script_build_phase("[XCRC] Mark")
-          mark_script.shell_script = "\"$SCRIPT_INPUT_FILE_0\" mark --configuration $CONFIGURATION --platform $PLATFORM_NAME"
+          mark_script.shell_script = "\"$SCRIPT_INPUT_FILE_0\" mark --configuration \"$CONFIGURATION\" --platform $PLATFORM_NAME"
           mark_script.input_paths = ["$SRCROOT/#{srcroot_relative_xc_location}/xcprepare"]
         else
           # Delete existing mark build phase (to support switching between modes or changing the final target)


### PR DESCRIPTION
### Description 

Build configs could contain a space in their names—e.g. "Debug Enterprise". 

The Mark script added to the final target invokes the `xcprepare mark` command with the configuration param without quotes, making the script fail when the config name contains a space in its name. 

The right way to invoke the command is: 

`xcprepare mark --configuration "$CONFIGURATION" --platform $PLATFORM_NAME` 

_Note: We have to escape the quotes inside the Build Phase script._ 