### PR TITLE
Integrate AWS Temporary Access Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ _Note that for the `producer` mode, the prebuild build phase and `xccc`, `xcld`,
 | `prettify_meta_files` | A Boolean value that opts-in pretty JSON formatting for meta files | `false` | ⬜️ |
 | `aws_secret_key` | Secret key for AWS V4 Signature Authorization. If this is set to a non-empty String - an Authentication Header will be added based on this and the other `aws_*` parameters.| `""` | ⬜️ |
 | `aws_access_key` | Access key for AWS V4 Signature Authorization. | `""` | ⬜️ |
+| `aws_security_token` | Temporary security token provided by the AWS Security Token Service. | `nil` | ⬜️ |
 | `aws_region` | Region for AWS V4 Signature Authorization. E.g. `eu`.  | `""` | ⬜️ |
 | `aws_service` | Service for AWS V4 Signature Authorization. E.g. `storage`. | `""` | ⬜️ |
 | `out_of_band_mappings` | A dictionary of files path remapping that should be applied to make it absolute path agnostic on a list of dependencies. Useful if a project refers files out of repo root, either compilation files or precompiled dependencies. Keys represent generic replacement and values are substrings that should be replaced. Example: for mapping `["COOL_LIBRARY": "/CoolLibrary"]` `/CoolLibrary/main.swift`will be represented as `$(COOL_LIBRARY)/main.swift`). Warning: remapping order is not-deterministic so avoid remappings with multiple matchings. | `[:]` | ⬜️ |
@@ -350,6 +351,8 @@ docker exec -w /tmp/cache -it xcremotecache /bin/bash
 XCRemoteCache supports Amazon S3 and Google Cloud Storage buckets to be used as cache servers using the Amazon v4 Signature Authorization.
 
 To set it up use the configuration parameters `aws_secret_key`, `aws_access_key`, `aws_region`, and `aws_service` in the `.rcinfo` file. Specify the URL to the bucket in cache-addresses field in the same file.
+
+XCRemoteCache also supports [AWS Temporary Access Keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#temporary-access-keys). Use additional `aws_security_token` parameter combined with `aws_secret_key`, `aws_access_key` to set it up. [This page](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) describes how to receive a security token. 
 
 Example
 ```yaml

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -114,6 +114,7 @@ public class XCPostbuild {
                 awsV4Signature = AWSV4Signature(
                     secretKey: config.AWSSecretKey,
                     accessKey: config.AWSAccessKey,
+                    securityToken: config.AWSSecurityToken,
                     region: config.AWSRegion,
                     service: config.AWSService,
                     date: Date(timeIntervalSinceNow: 0)

--- a/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
@@ -96,6 +96,7 @@ public class XCPrebuild {
                 awsV4Signature = AWSV4Signature(
                     secretKey: config.AWSSecretKey,
                     accessKey: config.AWSAccessKey,
+                    securityToken: config.AWSSecurityToken,
                     region: config.AWSRegion,
                     service: config.AWSService,
                     date: Date(timeIntervalSinceNow: 0)

--- a/Sources/XCRemoteCache/Commands/Prepare/XCPrepare.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/XCPrepare.swift
@@ -78,6 +78,7 @@ public class XCPrepare {
                 awsV4Signature = AWSV4Signature(
                     secretKey: config.AWSSecretKey,
                     accessKey: config.AWSAccessKey,
+                    securityToken: config.AWSSecurityToken,
                     region: config.AWSRegion,
                     service: config.AWSService,
                     date: Date(timeIntervalSinceNow: 0)

--- a/Sources/XCRemoteCache/Commands/Prepare/XCPrepareMark.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/XCPrepareMark.swift
@@ -60,6 +60,7 @@ public class XCPrepareMark {
                 awsV4Signature = AWSV4Signature(
                     secretKey: config.AWSSecretKey,
                     accessKey: config.AWSAccessKey,
+                    securityToken: config.AWSSecurityToken,
                     region: config.AWSRegion,
                     service: config.AWSService,
                     date: Date(timeIntervalSinceNow: 0)

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -118,6 +118,8 @@ public struct XCRemoteCacheConfig: Encodable {
     var AWSSecretKey: String = ""
     /// Access key for AWS V4 Signature
     var AWSAccessKey: String = ""
+    /// Temporary security token provided by the AWS Security Token Service
+    var AWSSecurityToken: String?
     /// Region for AWS V4 Signature (e.g. `eu`)
     var AWSRegion: String = ""
     /// Service for AWS V4 Signature (e.g. `storage`)
@@ -184,6 +186,7 @@ extension XCRemoteCacheConfig {
         merge.prettifyMetaFiles = scheme.prettifyMetaFiles ?? prettifyMetaFiles
         merge.AWSAccessKey = scheme.AWSAccessKey ?? AWSAccessKey
         merge.AWSSecretKey = scheme.AWSSecretKey ?? AWSSecretKey
+        merge.AWSSecurityToken = scheme.AWSSecurityToken ?? AWSSecurityToken
         merge.AWSRegion = scheme.AWSRegion ?? AWSRegion
         merge.AWSService = scheme.AWSService ?? AWSService
         merge.outOfBandMappings = scheme.outOfBandMappings ?? outOfBandMappings
@@ -247,6 +250,7 @@ struct ConfigFileScheme: Decodable {
     let prettifyMetaFiles: Bool?
     let AWSSecretKey: String?
     let AWSAccessKey: String?
+    let AWSSecurityToken: String?
     let AWSRegion: String?
     let AWSService: String?
     let outOfBandMappings: [String: String]?
@@ -293,6 +297,7 @@ struct ConfigFileScheme: Decodable {
         case prettifyMetaFiles = "prettify_meta_files"
         case AWSSecretKey = "aws_secret_key"
         case AWSAccessKey = "aws_access_key"
+        case AWSSecurityToken = "aws_security_token"
         case AWSRegion = "aws_region"
         case AWSService = "aws_service"
         case outOfBandMappings = "out_of_band_mappings"

--- a/Sources/XCRemoteCache/Network/Authentication/AWSV4Signature.swift
+++ b/Sources/XCRemoteCache/Network/Authentication/AWSV4Signature.swift
@@ -23,16 +23,20 @@ struct AWSV4Signature {
 
     let secretKey: String
     let accessKey: String
+    let securityToken: String?
     let region: String
     let service: String
     let date: Date
-
 
     func addSignatureHeaderTo(request: inout URLRequest) {
 
         request.setValue(request.url?.host, forHTTPHeaderField: "host")
         request.setValue(StringToSign.ISO8601BasicFormatter.string(from: date), forHTTPHeaderField: "x-amz-date")
         request.setValue((request.httpBody ?? Data()).sha256(), forHTTPHeaderField: "x-amz-content-sha256")
+        
+        if let securityToken = securityToken {
+            request.setValue(securityToken, forHTTPHeaderField: "x-amz-security-token")
+        }
 
         let canonicalRequest = CanonicalRequest(request: request)
         let stringToSign = StringToSign(

--- a/Tests/XCRemoteCacheTests/Network/Authentication/AWSV4SignatureTest.swift
+++ b/Tests/XCRemoteCacheTests/Network/Authentication/AWSV4SignatureTest.swift
@@ -35,10 +35,12 @@ class AWSV4SignatureTest: XCTestCase {
 
         let key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
         let accessKey = "AKIDEXAMPLE"
+        let securityToken = "IQoJb3JpZ2luX2VjENv//////////wEaCXVzLWVhc3Q+bsHwqnovXtl/1JVe61XHMnAw3AIXwOAOxqMvhw=="
 
         AWSV4Signature(
             secretKey: key,
             accessKey: accessKey,
+            securityToken: securityToken,
             region: "us-east-1",
             service: "iam",
             date: Date(timeIntervalSince1970: 1_440_938_160)
@@ -49,8 +51,8 @@ class AWSV4SignatureTest: XCTestCase {
     func testAuthHeaderContainsCorrectSignature() throws {
         XCTAssertEqual(
             "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, " +
-                "SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, " +
-                "Signature=dd479fa8a80364edf2119ec24bebde66712ee9c9cb2b0d92eb3ab9ccdc0c3947",
+                "SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token, " +
+                "Signature=d26ab974bba1b248f041ea1120064e1fa672d6f06cac2cff42b38acea87b76e5",
             request.allHTTPHeaderFields?["Authorization"]
         )
     }

--- a/Tests/XCRemoteCacheTests/Network/NetworkClientImplTests.swift
+++ b/Tests/XCRemoteCacheTests/Network/NetworkClientImplTests.swift
@@ -203,6 +203,7 @@ class NetworkClientImplTests: XCTestCase {
         let signature = AWSV4Signature(
             secretKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
             accessKey: "AKIDEXAMPLE",
+            securityToken: "IQoJb3JpZ2luX2VjENv//////////wEaCXVzLWVhc3Q+bsHwqnovXtl/1JVe61XHMnAw3AIXwOAOxqMvhw==",
             region: "us-east-1",
             service: "iam",
             date: Date(timeIntervalSince1970: 1_440_938_160)
@@ -213,8 +214,8 @@ class NetworkClientImplTests: XCTestCase {
 
         XCTAssertEqual(
             "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, " +
-                "SignedHeaders=host;x-amz-content-sha256;x-amz-date, " +
-                "Signature=acdb223475463b6ce711b063f199387a7a12bd638e4dccaaeb5efcbf159b6454",
+                "SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token, " +
+                "Signature=e5578464567fb97fd26e871702e4ec4ff7d61cb87eb72a40d22b80e12da30c34",
             try requests[0].allHTTPHeaderFields?["Authorization"].unwrap()
         )
     }


### PR DESCRIPTION
Hi XCRemoteCache Team!

I've added support for [AWS Temporary Access Keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#temporary-access-keys) by supplementing the `.rcinfo` file with the new `aws_security_token` parameter.

This change allows using _temporary security credentials_ instead of _static keys_, which may not be permitted for security reasons.

### Integration
Use `aws_security_token` combined with `aws_secret_key`, `aws_access_key` to set everything up.  
[This page](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) describes receiving a security token. 

```bash
# First, generate a token using the following command.
TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`

# Then, use the token to generate top-level metadata items using the following command
curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/
```

Let me know if you have any questions 🙂
