### PR TITLE
Fix error that moves the Prebuild phase script after the source phase

### DIFF
--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
@@ -146,8 +146,10 @@ module CocoapodsXCRemoteCacheModifier
           prebuild_script.dependency_file = "$(TARGET_TEMP_DIR)/prebuild.d"
 
           # Move prebuild (last element) to the position before compile sources phase (to make it real 'prebuild')
-          compile_phase_index = target.build_phases.index(target.source_build_phase)
-          target.build_phases.insert(compile_phase_index, target.build_phases.delete(prebuild_script))
+          if !existing_prebuild_script 
+            compile_phase_index = target.build_phases.index(target.source_build_phase)
+            target.build_phases.insert(compile_phase_index, target.build_phases.delete(prebuild_script))
+          end
         elsif mode == 'producer' || mode == 'producer-fast'
           # Delete existing prebuild build phase (to support switching between modes)
           target.build_phases.delete_if do |phase|


### PR DESCRIPTION
### Description 

Once I configure XCRemoteCache using the cocoapods plugin, when I reinstall the pods the script moves the "Prebuild" phase after the "Compile sources" phase.

<img width="1054" alt="Screen Shot 2022-04-11 at 11 17 37" src="https://user-images.githubusercontent.com/8599681/162759455-6609dcf7-91b6-4bc8-a2e9-ca9c6cd8e0f7.png">

### Solution 

Moving the Prebuild build phase is needed only the first time we insert it in the target build phases. When the build phase exists then it is already in the right order. 

