### PR TITLE
Load extra configuration in a chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ _Note that for the `producer` mode, the prebuild build phase and `xccc`, `xcld`,
 | `cache_commit_history` | Number of historical git commits to look for cache artifacts | `10` | ⬜️ |
 | `source_root` | Source root of the Xcode project | `""` | ⬜️ |
 | `fingerprint_override_extension` | Fingerprint override extension (sample override `Module.swiftmodule/x86_64.swiftmodule.md5`) | `md5` | ⬜️ |
-| `extra_configuration_file` | Configuration file that overrides project configuration | `user.rcinfo` | ⬜️ |
+| `extra_configuration_file` | Configuration file that overrides project configuration (this property can be overriden multiple times in different files to chain extra configuration files) | `user.rcinfo` | ⬜️ |
 | `publishing_sha` | Custom commit sha to publish artifact (producer only) | `nil` | ⬜️ |
 | `artifact_maximum_age` | Maximum age in days HTTP response should be locally cached before being evicted | `30` | ⬜️ |
 | `custom_fingerprint_envs` | Extra ENV keys that should be convoluted into the environment fingerprint | `[]` | ⬜️ |

--- a/Sources/XCRemoteCache/Commands/Libtool/XCLibtoolCreateUniversalBinary.swift
+++ b/Sources/XCRemoteCache/Commands/Libtool/XCLibtoolCreateUniversalBinary.swift
@@ -52,7 +52,7 @@ class XCLibtoolCreateUniversalBinary: XCLibtoolLogic {
         let config: XCRemoteCacheConfig
         do {
             let srcRoot: URL = URL(fileURLWithPath: fileManager.currentDirectoryPath)
-            config = try XCRemoteCacheConfigReader(srcRootPath: srcRoot.path, fileManager: fileManager)
+            config = try XCRemoteCacheConfigReader(srcRootPath: srcRoot.path, fileReader: fileManager)
                 .readConfiguration()
         } catch {
             errorLog("Libtool initialization failed with error: \(error). Fallbacking to libtool")

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -34,7 +34,7 @@ public class XCPostbuild {
         let context: PostbuildContext
         let cacheHitLogger: CacheHitLogger
         do {
-            config = try XCRemoteCacheConfigReader(env: env, fileManager: fileManager).readConfiguration()
+            config = try XCRemoteCacheConfigReader(env: env, fileReader: fileManager).readConfiguration()
             context = try PostbuildContext(config, env: env)
             updateProcessTag(context.targetName)
             let counterFactory: FileStatsCoordinator.CountersFactory = { file, count in

--- a/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
@@ -29,7 +29,7 @@ public class XCPrebuild {
         let config: XCRemoteCacheConfig
         let context: PrebuildContext
         do {
-            config = try XCRemoteCacheConfigReader(env: env, fileManager: fileManager).readConfiguration()
+            config = try XCRemoteCacheConfigReader(env: env, fileReader: fileManager).readConfiguration()
             context = try PrebuildContext(config, env: env)
             updateProcessTag(context.targetName)
         } catch {

--- a/Sources/XCRemoteCache/Commands/Prepare/Integrate/XCIntegrate.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/Integrate/XCIntegrate.swift
@@ -74,7 +74,7 @@ public class XCIntegrate {
             let binariesDir = commandURL.deletingLastPathComponent()
 
             let srcRoot: URL = URL(fileURLWithPath: projectPath).deletingLastPathComponent()
-            let config = try XCRemoteCacheConfigReader(srcRootPath: srcRoot.path, fileManager: fileManager)
+            let config = try XCRemoteCacheConfigReader(srcRootPath: srcRoot.path, fileReader: fileManager)
                 .readConfiguration()
 
             let context = try IntegrateContext(

--- a/Sources/XCRemoteCache/Commands/Prepare/XCConfig.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/XCConfig.swift
@@ -32,7 +32,7 @@ public class XCConfig {
         let fileManager = FileManager.default
         let config: XCRemoteCacheConfig
         do {
-            config = try XCRemoteCacheConfigReader(env: env, fileManager: fileManager).readConfiguration()
+            config = try XCRemoteCacheConfigReader(env: env, fileReader: fileManager).readConfiguration()
         } catch {
             exit(1, "FATAL: Prepare initialization failed with error: \(error)")
         }

--- a/Sources/XCRemoteCache/Commands/Prepare/XCPrepare.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/XCPrepare.swift
@@ -61,7 +61,7 @@ public class XCPrepare {
         var context: PrepareContext
         let xcodeVersion: String
         do {
-            config = try XCRemoteCacheConfigReader(env: env, fileManager: fileManager).readConfiguration()
+            config = try XCRemoteCacheConfigReader(env: env, fileReader: fileManager).readConfiguration()
             context = try PrepareContext(config, offline: offline)
             xcodeVersion = try customXcodeBuildNumber ?? XcodeProbeImpl(shell: shellGetStdout).read().buildVersion
         } catch {

--- a/Sources/XCRemoteCache/Commands/Prepare/XCPrepareMark.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/XCPrepareMark.swift
@@ -46,7 +46,7 @@ public class XCPrepareMark {
         let context: PrepareMarkContext
         let xcodeVersion: String
         do {
-            config = try XCRemoteCacheConfigReader(env: env, fileManager: fileManager).readConfiguration()
+            config = try XCRemoteCacheConfigReader(env: env, fileReader: fileManager).readConfiguration()
             context = try PrepareMarkContext(config)
             xcodeVersion = try xcode ?? XcodeProbeImpl(shell: shellGetStdout).read().buildVersion
         } catch {

--- a/Sources/XCRemoteCache/Commands/Prepare/XCStats.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/XCStats.swift
@@ -36,7 +36,7 @@ public class XCStats {
         let config: XCRemoteCacheConfig
         let context: XCStatsContext
         do {
-            config = try XCRemoteCacheConfigReader(env: env, fileManager: fileManager).readConfiguration()
+            config = try XCRemoteCacheConfigReader(env: env, fileReader: fileManager).readConfiguration()
             try context = XCStatsContext(config, fileManager: fileManager)
         } catch {
             exit(1, "FATAL: Prepare initialization failed with error: \(error)")

--- a/Sources/XCRemoteCache/Commands/ProductBinaryCreator/XCCreateBinary.swift
+++ b/Sources/XCRemoteCache/Commands/ProductBinaryCreator/XCCreateBinary.swift
@@ -70,7 +70,7 @@ public class XCCreateBinary {
         let config: XCRemoteCacheConfig
         do {
             let srcRoot: URL = URL(fileURLWithPath: fileManager.currentDirectoryPath)
-            config = try XCRemoteCacheConfigReader(srcRootPath: srcRoot.path, fileManager: fileManager)
+            config = try XCRemoteCacheConfigReader(srcRootPath: srcRoot.path, fileReader: fileManager)
                 .readConfiguration()
         } catch {
             errorLog("\(stepDescription) initialization failed with error: \(error). Fallbacking to \(fallbackCommand)")

--- a/Sources/XCRemoteCache/Commands/Swiftc/XCSwiftc.swift
+++ b/Sources/XCRemoteCache/Commands/Swiftc/XCSwiftc.swift
@@ -70,7 +70,7 @@ public class XCSwiftc {
         let context: SwiftcContext
         do {
             let srcRoot: URL = URL(fileURLWithPath: fileManager.currentDirectoryPath)
-            config = try XCRemoteCacheConfigReader(srcRootPath: srcRoot.path, fileManager: fileManager)
+            config = try XCRemoteCacheConfigReader(srcRootPath: srcRoot.path, fileReader: fileManager)
                 .readConfiguration()
             context = try SwiftcContext(config: config, input: inputArgs)
         } catch {

--- a/Tests/XCRemoteCacheTests/Config/XCRemoteCacheConfigReaderTests.swift
+++ b/Tests/XCRemoteCacheTests/Config/XCRemoteCacheConfigReaderTests.swift
@@ -26,6 +26,7 @@ class XCRemoteCacheConfigReaderTests: XCTestCase {
     private var reader: XCRemoteCacheConfigReader!
 
     override func setUp() {
+        super.setUp()
         fileReader = FileAccessorFake(mode: .normal)
         reader = XCRemoteCacheConfigReader(srcRootPath: "/", fileReader: fileReader)
     }

--- a/Tests/XCRemoteCacheTests/Config/XCRemoteCacheConfigReaderTests.swift
+++ b/Tests/XCRemoteCacheTests/Config/XCRemoteCacheConfigReaderTests.swift
@@ -1,0 +1,89 @@
+// Copyright (c) 2022 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@testable import XCRemoteCache
+import XCTest
+
+class XCRemoteCacheConfigReaderTests: XCTestCase {
+
+    func testReadsFromExtraConfig() throws {
+        let fileReader = FileAccessorFake(mode: .normal)
+        try fileReader.write(toPath: "/.rcinfo", contents: "cache_addresses: [test]")
+        let reader = XCRemoteCacheConfigReader(srcRootPath: "/", fileReader: fileReader)
+
+        let config = try reader.readConfiguration()
+
+        XCTAssertEqual(config.cacheAddresses, ["test"])
+    }
+
+    func testOverridesExtraConfigFromExtra() throws {
+        let fileReader = FileAccessorFake(mode: .normal)
+        try fileReader.write(toPath: "/.rcinfo", contents: "cache_addresses: [test]")
+        try fileReader.write(toPath: "/user.rcinfo", contents: "cache_addresses: [user]")
+        let reader = XCRemoteCacheConfigReader(srcRootPath: "/", fileReader: fileReader)
+
+        let config = try reader.readConfiguration()
+
+        XCTAssertEqual(config.cacheAddresses, ["user"])
+    }
+
+    func testReadsExtraMultipleTimes() throws {
+        let fileReader = FileAccessorFake(mode: .normal)
+        try fileReader.write(toPath: "/.rcinfo", contents: "cache_addresses: [test]")
+        try fileReader.write(toPath: "/user.rcinfo", contents: """
+        cache_addresses: [user]
+        extra_configuration_file: user2.rcinfo
+        """)
+        try fileReader.write(toPath: "/user2.rcinfo", contents: "cache_addresses: [user2]")
+        let reader = XCRemoteCacheConfigReader(srcRootPath: "/", fileReader: fileReader)
+
+        let config = try reader.readConfiguration()
+
+        XCTAssertEqual(config.cacheAddresses, ["user2"])
+    }
+
+    func testBreaksImportingIfReachingALoop() throws {
+        let fileReader = FileAccessorFake(mode: .normal)
+        try fileReader.write(toPath: "/.rcinfo", contents: "cache_addresses: [test]")
+        try fileReader.write(toPath: "/user.rcinfo", contents: """
+        cache_addresses: [user]
+        extra_configuration_file: .rcinfo
+        """)
+        let reader = XCRemoteCacheConfigReader(srcRootPath: "/", fileReader: fileReader)
+
+        let config = try reader.readConfiguration()
+
+        XCTAssertEqual(config.cacheAddresses, ["user"])
+    }
+
+    func testBreaksImportingIfExtraFileDoesntExist() throws {
+        let fileReader = FileAccessorFake(mode: .normal)
+        try fileReader.write(toPath: "/.rcinfo", contents: "cache_addresses: [test]")
+        try fileReader.write(toPath: "/user.rcinfo", contents: """
+        cache_addresses: [user]
+        extra_configuration_file: nonexisting.rcinfo
+        """)
+        let reader = XCRemoteCacheConfigReader(srcRootPath: "/", fileReader: fileReader)
+
+        let config = try reader.readConfiguration()
+
+        XCTAssertEqual(config.cacheAddresses, ["user"])
+        XCTAssertEqual(config.extraConfigurationFile, "nonexisting.rcinfo")
+    }
+}


### PR DESCRIPTION
Add chaining to the `extra_configuration_file`

`extra_configuration_file` allows overriding remote cache parameters from .yaml file. It has a limitation of only 2 files (by default .rcinfo + user.rcinfo) but in some more complex scenarios, it makes sense to have more files (e.g. to store AWS short-lived credentials).

This PR allows chaining them - XCRemoteCache reads and merges configurations transitively via `extra_configuration_file` until:
* the file doesn't exist
* or the file has already been visited in a chain (to avoid looping)

Fixes #114