### PR TITLE
Set auto-generated Swift header under DERIVED_FILES_DIR as irrelevant dependency

### DIFF
--- a/Sources/XCRemoteCache/Commands/Postbuild/PostbuildContext.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/PostbuildContext.swift
@@ -40,6 +40,7 @@ public struct PostbuildContext {
     var mode: Mode
     var targetName: String
     var targetTempDir: URL
+    var derivedFilesDir: URL
     /// Location where all compilation outputs (.o) are placed
     var compilationTempDir: URL
     var configuration: String
@@ -91,6 +92,7 @@ extension PostbuildContext {
         let targetNameValue: String = try env.readEnv(key: "TARGET_NAME")
         targetName = targetNameValue
         targetTempDir = try env.readEnv(key: "TARGET_TEMP_DIR")
+        derivedFilesDir = try env.readEnv(key: "DERIVED_FILE_DIR")
         let archs: [String] = try env.readEnv(key: "ARCHS").split(separator: " ").map(String.init)
         guard let firstArch = archs.first, !firstArch.isEmpty else {
             throw PostbuildContextError.missingArchitecture

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -170,6 +170,7 @@ public class XCPostbuild {
                 product: context.productsDir,
                 source: context.srcRoot,
                 intermediate: context.targetTempDir,
+                derivedFiles: context.derivedFilesDir,
                 bundle: context.bundleDir
             )
             // Override fingerprints for all produced '.swiftmodule' files

--- a/Tests/XCRemoteCacheTests/Commands/PostbuildContextTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/PostbuildContextTests.swift
@@ -26,6 +26,7 @@ class PostbuildContextTests: FileXCTestCase {
     private static let SampleEnvs = [
         "TARGET_NAME": "TARGET_NAME",
         "TARGET_TEMP_DIR": "TARGET_TEMP_DIR",
+        "DERIVED_FILE_DIR": "DERIVED_FILE_DIR",
         "ARCHS": "x86_64",
         "OBJECT_FILE_DIR_normal": "/OBJECT_FILE_DIR_normal" ,
         "CONFIGURATION": "CONFIGURATION",

--- a/Tests/XCRemoteCacheTests/Commands/PostbuildTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/PostbuildTests.swift
@@ -27,6 +27,7 @@ class PostbuildTests: FileXCTestCase {
         mode: .producer,
         targetName: "",
         targetTempDir: "",
+        derivedFilesDir: "",
         compilationTempDir: "",
         configuration: "",
         platform: "",
@@ -78,6 +79,7 @@ class PostbuildTests: FileXCTestCase {
         product: "/Product",
         source: "/Source",
         intermediate: "/Intermediate",
+        derivedFiles: "/DerivedFiles",
         bundle: nil
     )
     private var overrideManager = FingerprintOverrideManagerImpl(

--- a/Tests/XCRemoteCacheTests/Dependencies/DependencyProcessorImplTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/DependencyProcessorImplTests.swift
@@ -27,6 +27,7 @@ class DependencyProcessorImplTests: FileXCTestCase {
         product: "/Product",
         source: "/Source",
         intermediate: "/Intermediate",
+        derivedFiles: "/DerivedFiles",
         bundle: "/Bundle"
     )
 
@@ -37,6 +38,7 @@ class DependencyProcessorImplTests: FileXCTestCase {
             product: "/",
             source: "/",
             intermediate: "/Intermediate",
+            derivedFiles: "/DerivedFiles",
             bundle: nil
         )
 
@@ -53,6 +55,7 @@ class DependencyProcessorImplTests: FileXCTestCase {
             product: "/",
             source: "/",
             intermediate: "/Intermediate",
+            derivedFiles: "/DerivedFiles",
             bundle: "/Bundle"
         )
 
@@ -60,6 +63,14 @@ class DependencyProcessorImplTests: FileXCTestCase {
             processor.process([bundleFile]),
             []
         )
+    }
+
+    func testFiltersOutGeneratedSwiftHeaders() throws {
+        let dependencies = processor.process([
+            "/DerivedFiles/ModuleName-Swift.h",
+        ])
+
+        XCTAssertEqual(dependencies, [])
     }
 
     func testFiltersOutProductModulemap() throws {
@@ -130,6 +141,7 @@ class DependencyProcessorImplTests: FileXCTestCase {
             product: "/Product",
             source: "/Source",
             intermediate: intermediateDirReal,
+            derivedFiles: "/DerivedFiles",
             bundle: "/Bundle"
         )
 
@@ -158,6 +170,7 @@ class DependencyProcessorImplTests: FileXCTestCase {
             product: "/Product",
             source: sourceDirReal,
             intermediate: "/Intermediate",
+            derivedFiles: "/DerivedFiles",
             bundle: "/Bundle"
         )
 


### PR DESCRIPTION
Fixes https://github.com/spotify/XCRemoteCache/issues/101#issuecomment-1098313650.