### PR TITLE
Fix building target dependencies list with custom DERIVED_FILE_DIR

### DIFF
--- a/Sources/XCRemoteCache/Dependencies/DependencyProcessor.swift
+++ b/Sources/XCRemoteCache/Dependencies/DependencyProcessor.swift
@@ -107,16 +107,14 @@ class DependencyProcessorImpl: DependencyProcessor {
             return false
         }
 
-        if dependency.type == .derivedFile && dependency.url.lastPathComponent.contains("-Swift.h") {
-            return false
-        }
-
         // Skip:
         // - A fingerprint generated includes Xcode version build number so no need to analyze prepackaged Xcode files
         // - All files in `*/Interemediates/*` - this file are created on-fly for a given target
         // - Some files may depend on its own product (e.g. .m may #include *-Swift.h) - we know products will match
         //   because in case of a hit, these will be taken from the artifact
-        let irrelevantDependenciesType: [Dependency.Kind] = [.xcode, .intermediate, .ownProduct]
+        // - Customized DERIVED_FILE_DIR may change a directory of
+        //   derived files, which by default is under `*/Interemediates`
+        let irrelevantDependenciesType: [Dependency.Kind] = [.xcode, .intermediate, .ownProduct, .derivedFile]
         return !irrelevantDependenciesType.contains(dependency.type)
     }
 }

--- a/Sources/XCRemoteCache/Dependencies/DependencyProcessor.swift
+++ b/Sources/XCRemoteCache/Dependencies/DependencyProcessor.swift
@@ -80,6 +80,8 @@ class DependencyProcessorImpl: DependencyProcessor {
                 return Dependency(url: file, type: .xcode)
             } else if filePath.hasPrefix(intermediatePath) {
                 return Dependency(url: file, type: .intermediate)
+            } else if filePath.hasPrefix(derivedFilesPath) {
+                return Dependency(url: file, type: .derivedFile)
             } else if let bundle = bundlePath, filePath.hasPrefix(bundle) {
                 // If a target produces a bundle, explicitly classify all
                 // of products to distinguish from other targets products
@@ -88,8 +90,6 @@ class DependencyProcessorImpl: DependencyProcessor {
                 return Dependency(url: file, type: .product)
             } else if filePath.hasPrefix(sourcePath) {
                 return Dependency(url: file, type: .source)
-            } else if filePath.hasPrefix(derivedFilesPath) {
-                return Dependency(url: file, type: .derivedFile)
             } else {
                 return Dependency(url: file, type: .unknown)
             }

--- a/Tests/XCRemoteCacheTests/Dependencies/DependencyProcessorImplTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/DependencyProcessorImplTests.swift
@@ -73,6 +73,14 @@ class DependencyProcessorImplTests: FileXCTestCase {
         XCTAssertEqual(dependencies, [])
     }
 
+    func testFiltersOutDerivedFile() throws {
+        let dependencies = processor.process([
+            "/DerivedFiles/output.h",
+        ])
+
+        XCTAssertEqual(dependencies, [])
+    }
+
     func testFiltersOutProductModulemap() throws {
         let dependencies = processor.process([
             "/Product/some.modulemap",

--- a/Tests/XCRemoteCacheTests/Dependencies/DependencyProcessorImplTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/DependencyProcessorImplTests.swift
@@ -210,4 +210,21 @@ class DependencyProcessorImplTests: FileXCTestCase {
 
         return sourceDir.appendingPathComponent(filename)
     }
+
+    func testSkipsCustomizedDerivedDirFileUnderSources() {
+        let derivedFile: URL = "/DerivedFiles/Module-Swift.h"
+        let processor = DependencyProcessorImpl(
+            xcode: "/Xcode",
+            product: "/",
+            source: "/",
+            intermediate: "/Intermediate",
+            derivedFiles: "/DerivedFiles",
+            bundle: nil
+        )
+
+        XCTAssertEqual(
+            processor.process([derivedFile]),
+            []
+        )
+    }
 }


### PR DESCRIPTION
#121 follow-up

1. Fixing a scenario when someone sets DERIVED_FILE_DIR to `$(SRCROOT)/.build/BuckOutput`. Then, a derived files would classify that as a source instead of `.derivedFile` (see `testSkipsCustomizedDerivedDirFileUnderSources`)
2. Minor: only `*-Swift.h` files in `DerivedFilse` were not included in a dependency list. I don't see a reason why to be so strict and not skip all potential "internal" dependencies that are placed there. _So far I don't know any other files that could be generated there but in the future, Xcode may generate there something else than -Swift.h_.  