### PR TITLE
Fix xcode preview compile issue

### DIFF
--- a/Sources/xcld/XCLDMain.swift
+++ b/Sources/xcld/XCLDMain.swift
@@ -48,7 +48,16 @@ public class XCLDMain {
             i += 1
         }
         guard let outputInput = output, let filelistInput = filelist, let dependencyInfoInput = dependencyInfo else {
-            exit(1, "Missing 'output' argument. Args: \(args)")
+            let ldCommand = "clang"
+            print("Fallbacking to compilation using \(ldCommand).")
+
+            let args = ProcessInfo().arguments
+            let paramList = [ldCommand] + args.dropFirst()
+            let cargs = paramList.map { strdup($0) } + [nil]
+            execvp(ldCommand, cargs)
+
+            /// C-function `execv` returns only when the command fails
+            exit(1)
         }
 
 

--- a/Sources/xcswiftc/XCSwiftcMain.swift
+++ b/Sources/xcswiftc/XCSwiftcMain.swift
@@ -60,8 +60,16 @@ public class XCSwiftcMain {
             let targetInputInput = target,
             let swiftFileListInput = swiftFileList
             else {
-                print("Missing argument. Args: \(args)")
-                exit(1)
+            let swiftcCommand = "swiftc"
+            print("Fallbacking to compilation using \(swiftcCommand).")
+
+            let args = ProcessInfo().arguments
+            let paramList = [swiftcCommand] + args.dropFirst()
+            let cargs = paramList.map { strdup($0) } + [nil]
+            execvp(swiftcCommand, cargs)
+
+            /// C-function `execv` returns only when the command fails
+            exit(1)
         }
         let swiftcArgsInput = SwiftcArgInput(
             objcHeaderOutput: objcHeaderOutputInput,


### PR DESCRIPTION
When SWIFT_EXEC and LD is setted in a terget, files in the taget can not be previewed due to compile failure which is caused by missing argument.