### PR TITLE
cocoapods plugin support custom FAKE_SRCROOT

### DIFF
--- a/cocoapods-plugin/README.md
+++ b/cocoapods-plugin/README.md
@@ -53,6 +53,7 @@ An object that is passed to the `xcremotecache` can contain all properties suppo
 | `xccc_file` | The path where should be placed the `xccc` binary (in the pod installation phase) | `{podfile_dir}/.rc/xccc` | ⬜️ |
 | `remote_commit_file` | The path of the file with the remote commit sha (in the pod installation phase) | `{podfile_dir}/.rc/arc.rc`| ⬜️ |
 | `prettify_meta_files` | A Boolean value that opts-in pretty JSON formatting for meta files | `false` | ⬜️ |
+| `fake_src_root` | An arbitrary source location shared between producers and consumers. Should be unique for a project. | `/xxxxxxxxxx` | ⬜️ |
 | `disable_certificate_verification` | A Boolean value that opts-in SSL certificate validation is disabled | `false` | ⬜️ |
 
 ## Uninstalling

--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module CocoapodsXcremotecache
-  VERSION = "0.0.9"
+  VERSION = "0.0.10"
 end


### PR DESCRIPTION
FAKE_SRCROOT works for LLDB source-map, but this can't custom for the cocoapods plugin, make it annoy for multi projects, This add support fake_src_root for cocoapods plugin, works as same as --fake-src-root