### PR TITLE
Add irrelevant dependencies property

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ _Note that for the `producer` mode, the prebuild build phase and `xccc`, `xcld`,
 | `disable_certificate_verification` | A Boolean value that opts-in SSL certificate validation is disabled | `false` | ⬜️ |
 | `disable_vfs_overlay` | A feature flag to disable virtual file system overlay support (temporary) | `false` | ⬜️ |
 | `custom_rewrite_envs` | A list of extra ENVs that should be used as placeholders in the dependency list. ENV rewrite process is optimistic - does nothing if an ENV is not defined in the pre/postbuild process. | `[]` | ⬜️ |
+| `irrelevant_dependencies_paths` | Paths that should not be included in a list of dependencies Note: Can contain ENV placeholders, e.g. `[$(COOL_LIBRARY)]`. | `[]` | ⬜️ |
 
 ## Backend cache server
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ _Note that for the `producer` mode, the prebuild build phase and `xccc`, `xcld`,
 | `disable_certificate_verification` | A Boolean value that opts-in SSL certificate validation is disabled | `false` | ⬜️ |
 | `disable_vfs_overlay` | A feature flag to disable virtual file system overlay support (temporary) | `false` | ⬜️ |
 | `custom_rewrite_envs` | A list of extra ENVs that should be used as placeholders in the dependency list. ENV rewrite process is optimistic - does nothing if an ENV is not defined in the pre/postbuild process. | `[]` | ⬜️ |
-| `irrelevant_dependencies_paths` | Paths that should not be included in a list of dependencies Note: Can contain ENV placeholders, e.g. `[$(COOL_LIBRARY)]`. | `[]` | ⬜️ |
+| `irrelevant_dependencies_paths` | Regexes of files that should not be included in a list of dependencies. Warning! Be caution when adding entries here - excluding relevant dependencies might lead to targets overcaching. The regex can match either partially of fully the filepath, e.g. `\\.modulemap$` will exclude all `.modulemap` files.. | `[]` | ⬜️ |
 
 ## Backend cache server
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ _Note that for the `producer` mode, the prebuild build phase and `xccc`, `xcld`,
 | `disable_certificate_verification` | A Boolean value that opts-in SSL certificate validation is disabled | `false` | ⬜️ |
 | `disable_vfs_overlay` | A feature flag to disable virtual file system overlay support (temporary) | `false` | ⬜️ |
 | `custom_rewrite_envs` | A list of extra ENVs that should be used as placeholders in the dependency list. ENV rewrite process is optimistic - does nothing if an ENV is not defined in the pre/postbuild process. | `[]` | ⬜️ |
-| `irrelevant_dependencies_paths` | Regexes of files that should not be included in a list of dependencies. Warning! Be caution when adding entries here - excluding relevant dependencies might lead to targets overcaching. The regex can match either partially of fully the filepath, e.g. `\\.modulemap$` will exclude all `.modulemap` files.. | `[]` | ⬜️ |
+| `irrelevant_dependencies_paths` | Regexes of files that should not be included in a list of dependencies. Warning! Add entries here with caution - excluding dependencies that are relevant might lead to a target overcaching. The regex can match either partially or fully the filepath, e.g. `\\.modulemap$` will exclude all `.modulemap` files.. | `[]` | ⬜️ |
 
 ## Backend cache server
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ _Note that for the `producer` mode, the prebuild build phase and `xccc`, `xcld`,
 | `disable_certificate_verification` | A Boolean value that opts-in SSL certificate validation is disabled | `false` | ⬜️ |
 | `disable_vfs_overlay` | A feature flag to disable virtual file system overlay support (temporary) | `false` | ⬜️ |
 | `custom_rewrite_envs` | A list of extra ENVs that should be used as placeholders in the dependency list. ENV rewrite process is optimistic - does nothing if an ENV is not defined in the pre/postbuild process. | `[]` | ⬜️ |
-| `irrelevant_dependencies_paths` | Regexes of files that should not be included in a list of dependencies. Warning! Add entries here with caution - excluding dependencies that are relevant might lead to a target overcaching. The regex can match either partially or fully the filepath, e.g. `\\.modulemap$` will exclude all `.modulemap` files.. | `[]` | ⬜️ |
+| `irrelevant_dependencies_paths` | Regexes of files that should not be included in a list of dependencies. Warning! Add entries here with caution - excluding dependencies that are relevant might lead to a target overcaching. The regex can match either partially or fully the filepath, e.g. `\\.modulemap$` will exclude all `.modulemap` files. | `[]` | ⬜️ |
 
 ## Backend cache server
 

--- a/Sources/XCRemoteCache/Commands/Postbuild/PostbuildContext.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/PostbuildContext.swift
@@ -83,6 +83,7 @@ public struct PostbuildContext {
     /// location of the json file that define virtual files system overlay
     /// (mappings of the virtual location file -> local file path)
     let overlayHeadersPath: URL
+    let skippedDependenciesPaths: [String]
 }
 
 extension PostbuildContext {
@@ -135,5 +136,6 @@ extension PostbuildContext {
         modeMarkerPath = config.modeMarkerPath
         /// Note: The file has yaml extension, even it is in the json format
         overlayHeadersPath = targetTempDir.appendingPathComponent("all-product-headers.yaml")
+        skippedDependenciesPaths = config.irrelevantDependenciesPaths
     }
 }

--- a/Sources/XCRemoteCache/Commands/Postbuild/PostbuildContext.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/PostbuildContext.swift
@@ -83,7 +83,8 @@ public struct PostbuildContext {
     /// location of the json file that define virtual files system overlay
     /// (mappings of the virtual location file -> local file path)
     let overlayHeadersPath: URL
-    let skippedDependenciesPaths: [String]
+    /// Regexes of files that should not be included in the dependency list
+    let skippedDependenciesRegexes: [String]
 }
 
 extension PostbuildContext {
@@ -136,6 +137,6 @@ extension PostbuildContext {
         modeMarkerPath = config.modeMarkerPath
         /// Note: The file has yaml extension, even it is in the json format
         overlayHeadersPath = targetTempDir.appendingPathComponent("all-product-headers.yaml")
-        skippedDependenciesPaths = config.irrelevantDependenciesPaths
+        skippedDependenciesRegexes = config.irrelevantDependenciesPaths
     }
 }

--- a/Sources/XCRemoteCache/Commands/Postbuild/PostbuildContext.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/PostbuildContext.swift
@@ -84,7 +84,7 @@ public struct PostbuildContext {
     /// (mappings of the virtual location file -> local file path)
     let overlayHeadersPath: URL
     /// Regexes of files that should not be included in the dependency list
-    let skippedDependenciesRegexes: [String]
+    let irrelevantDependenciesPaths: [String]
 }
 
 extension PostbuildContext {
@@ -137,6 +137,6 @@ extension PostbuildContext {
         modeMarkerPath = config.modeMarkerPath
         /// Note: The file has yaml extension, even it is in the json format
         overlayHeadersPath = targetTempDir.appendingPathComponent("all-product-headers.yaml")
-        skippedDependenciesRegexes = config.irrelevantDependenciesPaths
+        irrelevantDependenciesPaths = config.irrelevantDependenciesPaths
     }
 }

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -166,13 +166,16 @@ public class XCPostbuild {
             }
             remappers.append(envsRemapper)
             let pathRemapper = DependenciesRemapperComposite(remappers)
+            let skippedDependenciesPaths = try pathRemapper.replace(genericPaths: context.skippedDependenciesPaths)
+            let skippedDependenciesURLs = skippedDependenciesPaths.map(URL.init(fileURLWithPath:))
             let dependencyProcessor = DependencyProcessorImpl(
                 xcode: context.xcodeDir,
                 product: context.productsDir,
                 source: context.srcRoot,
                 intermediate: context.targetTempDir,
                 derivedFiles: context.derivedFilesDir,
-                bundle: context.bundleDir
+                bundle: context.bundleDir,
+                skipped: skippedDependenciesURLs
             )
             // Override fingerprints for all produced '.swiftmodule' files
             let fingerprintOverrideManager = FingerprintOverrideManagerImpl(

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -173,7 +173,7 @@ public class XCPostbuild {
                 intermediate: context.targetTempDir,
                 derivedFiles: context.derivedFilesDir,
                 bundle: context.bundleDir,
-                skippedRegexes: context.skippedDependenciesRegexes
+                skippedRegexes: context.irrelevantDependenciesPaths
             )
             // Override fingerprints for all produced '.swiftmodule' files
             let fingerprintOverrideManager = FingerprintOverrideManagerImpl(

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -166,8 +166,6 @@ public class XCPostbuild {
             }
             remappers.append(envsRemapper)
             let pathRemapper = DependenciesRemapperComposite(remappers)
-            let skippedDependenciesPaths = try pathRemapper.replace(genericPaths: context.skippedDependenciesPaths)
-            let skippedDependenciesURLs = skippedDependenciesPaths.map(URL.init(fileURLWithPath:))
             let dependencyProcessor = DependencyProcessorImpl(
                 xcode: context.xcodeDir,
                 product: context.productsDir,
@@ -175,7 +173,7 @@ public class XCPostbuild {
                 intermediate: context.targetTempDir,
                 derivedFiles: context.derivedFilesDir,
                 bundle: context.bundleDir,
-                skipped: skippedDependenciesURLs
+                skippedRegexes: context.skippedDependenciesRegexes
             )
             // Override fingerprints for all produced '.swiftmodule' files
             let fingerprintOverrideManager = FingerprintOverrideManagerImpl(

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -139,9 +139,9 @@ public struct XCRemoteCacheConfig: Encodable {
     /// ENV rewrite process is optimistic - does nothing if an ENV is not defined in the pre/postbuild process
     var customRewriteEnvs: [String] = []
     /// Regexes of files that should not be included in a list of dependencies. Warning! Be caution when adding
-    /// entries here - excluding relevant dependencies might lead to targets overcaching.
+    /// entries here - excluding relevant dependencies might lead to targets overcaching
     /// The regex can match either partially of fully the filepath, e.g. `\\.modulemap$` will exclude
-    /// all `.modulemap` files.
+    /// all `.modulemap` files
     var irrelevantDependenciesPaths: [String] = []
 }
 

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -138,8 +138,10 @@ public struct XCRemoteCacheConfig: Encodable {
     /// A list of extra ENVs that should be used as placeholders in the dependency list
     /// ENV rewrite process is optimistic - does nothing if an ENV is not defined in the pre/postbuild process
     var customRewriteEnvs: [String] = []
-    /// Paths that should not be included in a list of dependencies
-    /// Note: Can contain ENV placeholders, e.g. `[$(COOL_LIBRARY)]`
+    /// Regexes of files that should not be included in a list of dependencies. Warning! Be caution when adding
+    /// entries here - excluding relevant dependencies might lead to targets overcaching.
+    /// The regex can match either partially of fully the filepath, e.g. `\\.modulemap$` will exclude
+    /// all `.modulemap` files.
     var irrelevantDependenciesPaths: [String] = []
 }
 

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -138,6 +138,9 @@ public struct XCRemoteCacheConfig: Encodable {
     /// A list of extra ENVs that should be used as placeholders in the dependency list
     /// ENV rewrite process is optimistic - does nothing if an ENV is not defined in the pre/postbuild process
     var customRewriteEnvs: [String] = []
+    /// Paths that should not be included in a list of dependencies
+    /// Note: Can contain ENV placeholders, e.g. `[$(COOL_LIBRARY)]`
+    var irrelevantDependenciesPaths: [String] = []
 }
 
 extension XCRemoteCacheConfig {
@@ -193,6 +196,7 @@ extension XCRemoteCacheConfig {
         merge.disableCertificateVerification = scheme.disableCertificateVerification ?? disableCertificateVerification
         merge.disableVFSOverlay = scheme.disableVFSOverlay ?? disableVFSOverlay
         merge.customRewriteEnvs = scheme.customRewriteEnvs ?? customRewriteEnvs
+        merge.irrelevantDependenciesPaths = scheme.irrelevantDependenciesPaths ?? irrelevantDependenciesPaths
         return merge
     }
 
@@ -257,6 +261,7 @@ struct ConfigFileScheme: Decodable {
     let disableCertificateVerification: Bool?
     let disableVFSOverlay: Bool?
     let customRewriteEnvs: [String]?
+    let irrelevantDependenciesPaths: [String]?
 
     // Yams library doesn't support encoding strategy, see https://github.com/jpsim/Yams/issues/84
     enum CodingKeys: String, CodingKey {
@@ -304,6 +309,7 @@ struct ConfigFileScheme: Decodable {
         case disableCertificateVerification = "disable_certificate_verification"
         case disableVFSOverlay = "disable_vfs_overlay"
         case customRewriteEnvs = "custom_rewrite_envs"
+        case irrelevantDependenciesPaths = "irrelevant_dependencies_paths"
     }
 }
 

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -138,9 +138,9 @@ public struct XCRemoteCacheConfig: Encodable {
     /// A list of extra ENVs that should be used as placeholders in the dependency list
     /// ENV rewrite process is optimistic - does nothing if an ENV is not defined in the pre/postbuild process
     var customRewriteEnvs: [String] = []
-    /// Regexes of files that should not be included in a list of dependencies. Warning! Be caution when adding
-    /// entries here - excluding relevant dependencies might lead to targets overcaching
-    /// The regex can match either partially of fully the filepath, e.g. `\\.modulemap$` will exclude
+    /// Regexes of files that should not be included in a list of dependencies. Warning! Add entries here
+    /// with caution - excluding dependencies that are relevant might lead to a target overcaching
+    /// Note: The regex can match either partially or fully the filepath, e.g. `\\.modulemap$` will exclude
     /// all `.modulemap` files
     var irrelevantDependenciesPaths: [String] = []
 }

--- a/Sources/XCRemoteCache/Dependencies/DependencyProcessor.swift
+++ b/Sources/XCRemoteCache/Dependencies/DependencyProcessor.swift
@@ -31,7 +31,7 @@ public struct Dependency: Equatable {
         // Product of the target itself
         case ownProduct
         // User-excluded path
-        case customSkipped
+        case userExcluded
         case unknown
     }
 
@@ -81,7 +81,7 @@ class DependencyProcessorImpl: DependencyProcessor {
         return files.map { file -> Dependency in
             let filePath = file.resolvingSymlinksInPath().path
             if skippedRegexes.contains(where: { filePath.range(of: $0, options: .regularExpression) != nil }) {
-                return Dependency(url: file, type: .customSkipped)
+                return Dependency(url: file, type: .userExcluded)
             } else if filePath.hasPrefix(xcodePath) {
                 return Dependency(url: file, type: .xcode)
             } else if filePath.hasPrefix(intermediatePath) {
@@ -120,8 +120,9 @@ class DependencyProcessorImpl: DependencyProcessor {
         //   because in case of a hit, these will be taken from the artifact
         // - Customized DERIVED_FILE_DIR may change a directory of
         //   derived files, which by default is under `*/Interemediates`
+        // - User-specified (in .rcinfo) files to exclude
         let irrelevantDependenciesType: [Dependency.Kind] = [
-            .xcode, .intermediate, .ownProduct, .derivedFile, .customSkipped,
+            .xcode, .intermediate, .ownProduct, .derivedFile, .userExcluded,
         ]
         return !irrelevantDependenciesType.contains(dependency.type)
     }

--- a/Tests/XCRemoteCacheTests/Commands/PostbuildTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/PostbuildTests.swift
@@ -55,7 +55,7 @@ class PostbuildTests: FileXCTestCase {
         action: .build,
         modeMarkerPath: "",
         overlayHeadersPath: "",
-        skippedDependenciesPaths: []
+        skippedDependenciesRegexes: []
     )
     private var network = RemoteNetworkClientImpl(
         NetworkClientFake(fileManager: .default),
@@ -82,7 +82,7 @@ class PostbuildTests: FileXCTestCase {
         intermediate: "/Intermediate",
         derivedFiles: "/DerivedFiles",
         bundle: nil,
-        skipped: []
+        skippedRegexes: []
     )
     private var overrideManager = FingerprintOverrideManagerImpl(
         overridingFileExtensions: ["swiftmodule"],

--- a/Tests/XCRemoteCacheTests/Commands/PostbuildTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/PostbuildTests.swift
@@ -54,7 +54,8 @@ class PostbuildTests: FileXCTestCase {
         thinnedTargets: [],
         action: .build,
         modeMarkerPath: "",
-        overlayHeadersPath: ""
+        overlayHeadersPath: "",
+        skippedDependenciesPaths: []
     )
     private var network = RemoteNetworkClientImpl(
         NetworkClientFake(fileManager: .default),
@@ -80,7 +81,8 @@ class PostbuildTests: FileXCTestCase {
         source: "/Source",
         intermediate: "/Intermediate",
         derivedFiles: "/DerivedFiles",
-        bundle: nil
+        bundle: nil,
+        skipped: []
     )
     private var overrideManager = FingerprintOverrideManagerImpl(
         overridingFileExtensions: ["swiftmodule"],

--- a/Tests/XCRemoteCacheTests/Commands/PostbuildTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/PostbuildTests.swift
@@ -55,7 +55,7 @@ class PostbuildTests: FileXCTestCase {
         action: .build,
         modeMarkerPath: "",
         overlayHeadersPath: "",
-        skippedDependenciesRegexes: []
+        irrelevantDependenciesPaths: []
     )
     private var network = RemoteNetworkClientImpl(
         NetworkClientFake(fileManager: .default),

--- a/Tests/XCRemoteCacheTests/Dependencies/DependencyProcessorImplTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/DependencyProcessorImplTests.swift
@@ -29,10 +29,10 @@ class DependencyProcessorImplTests: FileXCTestCase {
         intermediate: "/Intermediate",
         derivedFiles: "/DerivedFiles",
         bundle: "/Bundle",
-        skipped: []
+        skippedRegexes: []
     )
 
-    func testIntermediateFileIsSkippedForProductAndSourceSubdirectory() {
+    func testIntermediateFileIsskippedRegexesForProductAndSourceSubdirectory() {
         let intermediateFile: URL = "/Intermediate/some"
         let processor = DependencyProcessorImpl(
             xcode: "/Xcode",
@@ -41,7 +41,7 @@ class DependencyProcessorImplTests: FileXCTestCase {
             intermediate: "/Intermediate",
             derivedFiles: "/DerivedFiles",
             bundle: nil,
-            skipped: []
+            skippedRegexes: []
         )
 
         XCTAssertEqual(
@@ -50,7 +50,7 @@ class DependencyProcessorImplTests: FileXCTestCase {
         )
     }
 
-    func testBundleFileIsSkippedForProductAndSourceSubdirectory() {
+    func testBundleFileIsskippedRegexesForProductAndSourceSubdirectory() {
         let bundleFile: URL = "/Bundle/some"
         let processor = DependencyProcessorImpl(
             xcode: "/Xcode",
@@ -59,7 +59,7 @@ class DependencyProcessorImplTests: FileXCTestCase {
             intermediate: "/Intermediate",
             derivedFiles: "/DerivedFiles",
             bundle: "/Bundle",
-            skipped: []
+            skippedRegexes: []
         )
 
         XCTAssertEqual(
@@ -154,7 +154,7 @@ class DependencyProcessorImplTests: FileXCTestCase {
             intermediate: intermediateDirReal,
             derivedFiles: "/DerivedFiles",
             bundle: "/Bundle",
-            skipped: []
+            skippedRegexes: []
         )
 
         let intermediateFileSymlink = createSymlink(
@@ -184,7 +184,7 @@ class DependencyProcessorImplTests: FileXCTestCase {
             intermediate: "/Intermediate",
             derivedFiles: "/DerivedFiles",
             bundle: "/Bundle",
-            skipped: []
+            skippedRegexes: []
         )
 
         let sourceFileSymlink = createSymlink(
@@ -225,12 +225,66 @@ class DependencyProcessorImplTests: FileXCTestCase {
             intermediate: "/Intermediate",
             derivedFiles: "/DerivedFiles",
             bundle: nil,
-            skipped: []
+            skippedRegexes: []
         )
 
         XCTAssertEqual(
             processor.process([derivedFile]),
             []
+        )
+    }
+
+    func testSkippsFilesWithFullMatch() {
+        let source: URL = "/someFile.m"
+        let processor = DependencyProcessorImpl(
+            xcode: "/Xcode",
+            product: "/",
+            source: "/",
+            intermediate: "/Intermediate",
+            derivedFiles: "/DerivedFiles",
+            bundle: nil,
+            skippedRegexes: ["/someFile\\.m"]
+        )
+
+        XCTAssertEqual(
+            processor.process([source]),
+            []
+        )
+    }
+
+    func testSkippsFilesWithPartialMatch() {
+        let derivedModulemap: URL = "/module.modulemap"
+        let processor = DependencyProcessorImpl(
+            xcode: "/Xcode",
+            product: "/product",
+            source: "/",
+            intermediate: "/Intermediate",
+            derivedFiles: "/DerivedFiles",
+            bundle: nil,
+            skippedRegexes: ["\\.modulemap$"]
+        )
+
+        XCTAssertEqual(
+            processor.process([derivedModulemap]),
+            []
+        )
+    }
+
+    func testDoesntSkipFileIfInvalidRegex() {
+        let source: URL = "/someFile.m"
+        let processor = DependencyProcessorImpl(
+            xcode: "/Xcode",
+            product: "/product",
+            source: "/",
+            intermediate: "/Intermediate",
+            derivedFiles: "/DerivedFiles",
+            bundle: nil,
+            skippedRegexes: ["\\"]
+        )
+
+        XCTAssertEqual(
+            processor.process([source]),
+            [.init(url: source, type: .source)]
         )
     }
 }

--- a/Tests/XCRemoteCacheTests/Dependencies/DependencyProcessorImplTests.swift
+++ b/Tests/XCRemoteCacheTests/Dependencies/DependencyProcessorImplTests.swift
@@ -28,7 +28,8 @@ class DependencyProcessorImplTests: FileXCTestCase {
         source: "/Source",
         intermediate: "/Intermediate",
         derivedFiles: "/DerivedFiles",
-        bundle: "/Bundle"
+        bundle: "/Bundle",
+        skipped: []
     )
 
     func testIntermediateFileIsSkippedForProductAndSourceSubdirectory() {
@@ -39,7 +40,8 @@ class DependencyProcessorImplTests: FileXCTestCase {
             source: "/",
             intermediate: "/Intermediate",
             derivedFiles: "/DerivedFiles",
-            bundle: nil
+            bundle: nil,
+            skipped: []
         )
 
         XCTAssertEqual(
@@ -56,7 +58,8 @@ class DependencyProcessorImplTests: FileXCTestCase {
             source: "/",
             intermediate: "/Intermediate",
             derivedFiles: "/DerivedFiles",
-            bundle: "/Bundle"
+            bundle: "/Bundle",
+            skipped: []
         )
 
         XCTAssertEqual(
@@ -150,7 +153,8 @@ class DependencyProcessorImplTests: FileXCTestCase {
             source: "/Source",
             intermediate: intermediateDirReal,
             derivedFiles: "/DerivedFiles",
-            bundle: "/Bundle"
+            bundle: "/Bundle",
+            skipped: []
         )
 
         let intermediateFileSymlink = createSymlink(
@@ -179,7 +183,8 @@ class DependencyProcessorImplTests: FileXCTestCase {
             source: sourceDirReal,
             intermediate: "/Intermediate",
             derivedFiles: "/DerivedFiles",
-            bundle: "/Bundle"
+            bundle: "/Bundle",
+            skipped: []
         )
 
         let sourceFileSymlink = createSymlink(
@@ -219,7 +224,8 @@ class DependencyProcessorImplTests: FileXCTestCase {
             source: "/",
             intermediate: "/Intermediate",
             derivedFiles: "/DerivedFiles",
-            bundle: nil
+            bundle: nil,
+            skipped: []
         )
 
         XCTAssertEqual(


### PR DESCRIPTION
Adding an extra .rcinfo property `irrelevant_dependencies_paths` that defines custom files that shouldn't be considered as target dependencies in meta (and thus fingerprint generation). 

Finding a precise list of dependencies is crucial to obtain reliability with XCRemoteCache. In some cases, clang or swift compilers could include some excessive files (e.g. `modulemap`), even these files are not relevant to the compilation product. If an owner of the project knows with certainty that a given file(s) shouldn't be considered as a dependency,  `irrelevant_dependencies_paths` could be helpful to get rid of these "virtual" dependencies. 
Note! As written in the docs - adding entries to `irrelevant_dependencies_paths` should be rare and an extensive consideration of potential repercussions/limitations should always be carried out.  

This PR could be helpful to unblock #126.