### PR TITLE
Fix hybrid incremental performance

### DIFF
--- a/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
@@ -189,8 +189,8 @@ public class XCPrebuild {
             case .compatible(localDependencies: let dependencies):
                 // TODO: pass `allowedInputFiles` observed in the build time
                 try modeController.enable(allowedInputFiles: dependencies, dependencies: dependencies)
-                compilationHistoryOrganizer.reset()
             }
+            compilationHistoryOrganizer.reset()
         } catch {
             disableRemoteCache(
                 modeController: modeController,

--- a/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
@@ -78,6 +78,10 @@ public class XCPrebuild {
             exit(0)
         }
 
+        let compilationHistoryOrganizer = CompilationHistoryFileOrganizer(
+            context.compilationHistoryFile,
+            fileManager: fileManager
+        )
         do {
             let envFingerprint = try EnvironmentFingerprintGenerator(
                 configuration: config,
@@ -148,10 +152,6 @@ public class XCPrebuild {
                 algorithm: MD5Algorithm()
             )
             let organizer = ZipArtifactOrganizer(targetTempDir: context.targetTempDir, fileManager: fileManager)
-            let compilationHistoryOrganizer = CompilationHistoryFileOrganizer(
-                context.compilationHistoryFile,
-                fileManager: fileManager
-            )
             let metaReader = JsonMetaReader(fileAccessor: fileManager)
             var consumerPlugins: [ArtifactConsumerPrebuildPlugin] = []
 
@@ -189,7 +189,6 @@ public class XCPrebuild {
             case .compatible(localDependencies: let dependencies):
                 // TODO: pass `allowedInputFiles` observed in the build time
                 try modeController.enable(allowedInputFiles: dependencies, dependencies: dependencies)
-                compilationHistoryOrganizer.reset()
             }
         } catch {
             disableRemoteCache(
@@ -197,6 +196,7 @@ public class XCPrebuild {
                 errorMessage: "Prebuild step failed with error: \(error)"
             )
         }
+        compilationHistoryOrganizer.reset()
     }
 
     private func disableRemoteCache(modeController: PhaseCacheModeController, errorMessage: String?) {

--- a/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
@@ -189,8 +189,8 @@ public class XCPrebuild {
             case .compatible(localDependencies: let dependencies):
                 // TODO: pass `allowedInputFiles` observed in the build time
                 try modeController.enable(allowedInputFiles: dependencies, dependencies: dependencies)
+                compilationHistoryOrganizer.reset()
             }
-            compilationHistoryOrganizer.reset()
         } catch {
             disableRemoteCache(
                 modeController: modeController,

--- a/Sources/XCRemoteCache/Dependencies/CacheModeController.swift
+++ b/Sources/XCRemoteCache/Dependencies/CacheModeController.swift
@@ -77,9 +77,9 @@ class PhaseCacheModeController: CacheModeController {
         // and should invalidate all other target steps (swiftc,libtool etc.)
         let targetSensitiveFiles = dependencies + [modeMarker, Self.xcodeSelectLink]
         try markerWriter.enable(dependencies: targetSensitiveFiles)
-        // All rc-phases (prebuid & postbuild) should be reenabled when a new remote
-        // merge commit is used, the target is forced to compile locally or other Xcode is used
-        let allDependencies = dependencies + [mergeCommitFile, modeMarker, Self.xcodeSelectLink]
+        // All rc-phases (prebuid & postbuild) should be reenabled when new remote
+        // merge commit or other Xcode is used
+        let allDependencies = dependencies + [mergeCommitFile, Self.xcodeSelectLink]
         try dependenciesWriter.writeGeneric(dependencies: allDependencies)
     }
 

--- a/Sources/XCRemoteCache/Dependencies/CacheModeController.swift
+++ b/Sources/XCRemoteCache/Dependencies/CacheModeController.swift
@@ -77,9 +77,9 @@ class PhaseCacheModeController: CacheModeController {
         // and should invalidate all other target steps (swiftc,libtool etc.)
         let targetSensitiveFiles = dependencies + [modeMarker, Self.xcodeSelectLink]
         try markerWriter.enable(dependencies: targetSensitiveFiles)
-        // All rc-phases (prebuid & postbuild) should be reenabled when new remote
-        // merge commit or other Xcode is used
-        let allDependencies = dependencies + [mergeCommitFile, Self.xcodeSelectLink]
+        // All rc-phases (prebuid & postbuild) should be reenabled when a new remote
+        // merge commit is used, the target is forced to compile locally or other Xcode is used
+        let allDependencies = dependencies + [mergeCommitFile, modeMarker, Self.xcodeSelectLink]
         try dependenciesWriter.writeGeneric(dependencies: allDependencies)
     }
 


### PR DESCRIPTION
When a Hybrid target is fallbacking to a local build, it invokes all commands from `history.compile`, even it makes no sense as Xcode will trigger them anyway. Because invoking commands from `history.compile` happens without parallelization, that bug could lead to a very slow incremental builds.

Project to reproduce a problem: https://github.com/polac24/HybridXCRemoteCache

This fix cleans the `history.compile` file in all cases, no matter if there has been: cache hit, cache miss or even an error.

Fixes #133