### PR TITLE
Support Vendored frameworks in the CocoaPods development pod

### DIFF
--- a/cocoapods-plugin/README.md
+++ b/cocoapods-plugin/README.md
@@ -63,7 +63,3 @@ To fully uninstall the plugin, call:
 ```bash
 gem uninstall cocoapods-xcremotecache
 ```
-
-## Limitations
-
-* When `generate_multiple_pod_projects` mode is enabled, only first-party targets are cached by XCRemoteCache (all dependencies are compiled locally).

--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module CocoapodsXcremotecache
-  VERSION = "0.0.11"
+  VERSION = "0.0.12"
 end


### PR DESCRIPTION
If a development pod uses vendored_frameworks, the precompiled .framework is referenced from the `{RootProject}/Modules`, while all development Pods' `SRCROOT` are placed in `{RootProject}/Pods`. As a result, all files referenced dependencies from `Modules` use absolute paths (because that path is outside of `SRCROOT` or any other observed paths).

This PR allows referencing any file from the `{RootProject}` - both in the main project or Pods project. 

Impl details: sometimes we have to set `./../` (for Pods projects) and `./` (the main one) but fortunately, we already have logic for that because we reference xcprebuild, xcpostbuild etc. apps via `{RootProject}`. An idea is that all Xcode projects contain a build setting `XCRC_COOCAPODS_ROOT` that points to the `{RootProject}`. That ENV is always added to the `custom_rewrite_envs` so XCRemoteCahce knows to replace that path into a generic location: 

 #### Pods project
<img width="739" alt="Screenshot 2022-05-17 at 19 58 53" src="https://user-images.githubusercontent.com/9629417/168879597-eca49243-ac27-4207-ac46-f6d76a7bb899.png">
#### Main project 
<img width="661" alt="Screenshot 2022-05-17 at 20 00 05" src="https://user-images.githubusercontent.com/9629417/168879618-12eaeceb-a92c-4b6c-b42a-bb2b9cb50747.png">

#### How to test:
Sample project: https://github.com/canhth/nestedCocoapodsSample

name1's meta before:
```
{
  "inputs" : [

  ],
  "generationCommit" : "7417971ddde58a792d216a6468a1e0368f05ff74",
  "pluginsKeys" : {

  },
  "targetName" : "name1",
  "platform" : "iphoneos",
  "configuration" : "Debug",
  "rawFingerprint" : "952798faf4b055f19d97fec1c7fa5dc8",
  "fileKey" : "35d9d517b94bec38813884af68ab2173",
  "dependencies" : [
    "$(BUILD_DIR)\/Debug-iphoneos\/FaceDetection\/FaceDetection.framework\/Modules\/module.modulemap",
    "$(BUILD_DIR)\/Debug-iphoneos\/name2\/name2.framework\/Modules\/module.modulemap",
    "$(BUILD_DIR)\/Debug-iphoneos\/FaceDetection\/FaceDetection.framework\/Headers\/FaceDetection-Swift.h",
    "$(BUILD_DIR)\/Debug-iphoneos\/FaceDetection\/FaceDetection.framework\/Modules\/FaceDetection.swiftmodule\/arm64-apple-ios.swiftmodule.md5",
    "$(BUILD_DIR)\/Debug-iphoneos\/name2\/name2.framework\/Headers\/name2-Swift.h",
    "$(BUILD_DIR)\/Debug-iphoneos\/name2\/name2.framework\/Modules\/name2.swiftmodule\/arm64-apple-ios.swiftmodule.md5",
    "/Some/Absolute/path\/Modules\/FaceDetection\/FaceDetection\/Frameworks\/KYCQualityDetection.framework\/Headers\/GojekCV.h",
    "/Some/Absolute/path\/Modules\/FaceDetection\/FaceDetection\/Frameworks\/KYCQualityDetection.framework\/Headers\/HelperClasses.h",
    "/Some/Absolute/path\/Modules\/FaceDetection\/FaceDetection\/Frameworks\/KYCQualityDetection.framework\/Modules\/module.modulemap",
    "/Some/Absolute/path\/Modules\/name1\/name1\/Classes\/ReplaceMe.swift",
    "$(BUILD_DIR)\/Debug-iphoneos\/FaceDetection\/FaceDetection.framework\/Headers\/FaceDetection-umbrella.h",
    "$(SRCROOT)\/Target Support Files\/name1\/name1-dummy.m",
    "$(SRCROOT)\/Target Support Files\/name1\/name1-prefix.pch",
    "$(BUILD_DIR)\/Debug-iphoneos\/name1\/name1.framework\/Headers\/name1-umbrella.h",
    "$(BUILD_DIR)\/Debug-iphoneos\/name2\/name2.framework\/Headers\/name2-umbrella.h"
  ],
  "xcode" : "13C100"
}
``` 
name1's meta after: 
```
{
  "inputs" : [

  ],
  "generationCommit" : "7417971ddde58a792d216a6468a1e0368f05ff74",
  "pluginsKeys" : {

  },
  "targetName" : "name1",
  "platform" : "iphoneos",
  "configuration" : "Debug",
  "rawFingerprint" : "952798faf4b055f19d97fec1c7fa5dc8",
  "fileKey" : "35d9d517b94bec38813884af68ab2173",
  "dependencies" : [
    "$(BUILD_DIR)\/Debug-iphoneos\/FaceDetection\/FaceDetection.framework\/Modules\/module.modulemap",
    "$(BUILD_DIR)\/Debug-iphoneos\/name2\/name2.framework\/Modules\/module.modulemap",
    "$(BUILD_DIR)\/Debug-iphoneos\/FaceDetection\/FaceDetection.framework\/Headers\/FaceDetection-Swift.h",
    "$(BUILD_DIR)\/Debug-iphoneos\/FaceDetection\/FaceDetection.framework\/Modules\/FaceDetection.swiftmodule\/arm64-apple-ios.swiftmodule.md5",
    "$(BUILD_DIR)\/Debug-iphoneos\/name2\/name2.framework\/Headers\/name2-Swift.h",
    "$(BUILD_DIR)\/Debug-iphoneos\/name2\/name2.framework\/Modules\/name2.swiftmodule\/arm64-apple-ios.swiftmodule.md5",
    "$(XCRC_COOCAPODS_ROOT)\/Modules\/FaceDetection\/FaceDetection\/Frameworks\/KYCQualityDetection.framework\/Headers\/GojekCV.h",
    "$(XCRC_COOCAPODS_ROOT)\/Modules\/FaceDetection\/FaceDetection\/Frameworks\/KYCQualityDetection.framework\/Headers\/HelperClasses.h",
    "$(XCRC_COOCAPODS_ROOT)\/Modules\/FaceDetection\/FaceDetection\/Frameworks\/KYCQualityDetection.framework\/Modules\/module.modulemap",
    "$(XCRC_COOCAPODS_ROOT)\/Modules\/name1\/name1\/Classes\/ReplaceMe.swift",
    "$(BUILD_DIR)\/Debug-iphoneos\/FaceDetection\/FaceDetection.framework\/Headers\/FaceDetection-umbrella.h",
    "$(SRCROOT)\/Target Support Files\/name1\/name1-dummy.m",
    "$(SRCROOT)\/Target Support Files\/name1\/name1-prefix.pch",
    "$(BUILD_DIR)\/Debug-iphoneos\/name1\/name1.framework\/Headers\/name1-umbrella.h",
    "$(BUILD_DIR)\/Debug-iphoneos\/name2\/name2.framework\/Headers\/name2-umbrella.h"
  ],
  "xcode" : "13C100"
}
```

Fixes #134