### PR TITLE
[CocoaPodsPlugin] Regenerate cached projects when XCRC is finally on

### DIFF
--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module CocoapodsXcremotecache
-  VERSION = "0.0.13"
+  VERSION = "0.0.14"
 end


### PR DESCRIPTION
Support pods project/target regeneration when `incremental_installation` is enabled: in the preinstall the plugin checks if the XCRemoteCache changes for disabled -> enabled. If so, it forces Pods project/targets regeneration by deleting the previous cache model, provided by the sandbox class (e.g. `Pods/.project_cache/installation_cache.yaml`). Removing this file has to happen in the preinstall, before the cache invalidation is inspected. 

This PR moves also some essential xcrc cocoapods plugin steps (like downloading XCRC binaries from the Internet) from post-install to preinstall because these are needed to discriminate if the remote cache is enabled/disabled.

#### How to test?
1. Install first the project with no artifacts. Sample Podfile: 
```
install!('cocoapods', incremental_installation: true, generate_multiple_pod_projects: true)

plugin 'cocoapods-xcremotecache'


xcremotecache({
    'cache_addresses' => ['http://localhost:8080/cache/pods'], 
    'primary_repo' => '.',
    'mode' => 'consumer'
})

target 'Generate' do
  # Comment the next line if you don't want to use dynamic frameworks
  use_frameworks!

  pod 'Firebase/Analytics'
  pod 'ReactiveSwift'
end
```
2. Upload remote cache artifacts
3. Call `pod install`
4.  Expect extra builds steps (and build settings) in all Pods project

Fixes #155 
