### PR TITLE
Add a delay between network request retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ _Note that for the `producer` mode, the prebuild build phase and `xccc`, `xcld`,
 | `stats_dir` | Directory where all XCRemoteCache statistics (e.g. counters) are stored | `~/.xccache` | ⬜️ |
 | `download_retries` | Number of retries for download requests | `0` | ⬜️ |
 | `upload_retries` | Number of retries for upload requests | `3` | ⬜️ |
-| `retryDelay` | Delay between retries in seconds | `10` | ⬜️ |
+| `retry_delay` | Delay between retries in seconds | `10` | ⬜️ |
 | `request_custom_headers` | Dictionary of extra HTTP headers for all remote server requests | `[]` | ⬜️ |
 | `thin_target_mock_filename` | Filename (without an extension) of the compilation input file that is used as a fake compilation for the forced-cached target (aka thin target) | `standin` | ⬜️ |
 | `focused_targets` | A list of all targets that are not thinned. If empty, all targets are meant to be non-thin | `[]` | ⬜️ |

--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ _Note that for the `producer` mode, the prebuild build phase and `xccc`, `xcld`,
 | `stats_dir` | Directory where all XCRemoteCache statistics (e.g. counters) are stored | `~/.xccache` | ⬜️ |
 | `download_retries` | Number of retries for download requests | `0` | ⬜️ |
 | `upload_retries` | Number of retries for upload requests | `3` | ⬜️ |
+| `retryDelay` | Delay between retries in seconds | `10` | ⬜️ |
 | `request_custom_headers` | Dictionary of extra HTTP headers for all remote server requests | `[]` | ⬜️ |
 | `thin_target_mock_filename` | Filename (without an extension) of the compilation input file that is used as a fake compilation for the forced-cached target (aka thin target) | `standin` | ⬜️ |
 | `focused_targets` | A list of all targets that are not thinned. If empty, all targets are meant to be non-thin | `[]` | ⬜️ |

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -123,6 +123,7 @@ public class XCPostbuild {
             let networkClient = NetworkClientImpl(
                 session: sessionFactory.build(),
                 retries: config.uploadRetries,
+                retryDelay: config.retryDelay,
                 fileManager: fileManager,
                 awsV4Signature: awsV4Signature
             )

--- a/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
+++ b/Sources/XCRemoteCache/Commands/Prebuild/XCPrebuild.swift
@@ -109,6 +109,7 @@ public class XCPrebuild {
             let networkClient = NetworkClientImpl(
                 session: sessionFactory.build(),
                 retries: config.downloadRetries,
+                retryDelay: config.retryDelay,
                 fileManager: fileManager,
                 awsV4Signature: awsV4Signature
             )

--- a/Sources/XCRemoteCache/Commands/Prepare/XCPrepare.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/XCPrepare.swift
@@ -87,6 +87,7 @@ public class XCPrepare {
             let networkClient = NetworkClientImpl(
                 session: sessionFactory.build(),
                 retries: config.downloadRetries,
+                retryDelay: config.retryDelay,
                 fileManager: fileManager,
                 awsV4Signature: awsV4Signature
             )

--- a/Sources/XCRemoteCache/Commands/Prepare/XCPrepareMark.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/XCPrepareMark.swift
@@ -69,6 +69,7 @@ public class XCPrepareMark {
             let networkClient = NetworkClientImpl(
                 session: sessionFactory.build(),
                 retries: config.uploadRetries,
+                retryDelay: config.retryDelay,
                 fileManager: fileManager,
                 awsV4Signature: awsV4Signature
             )

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -359,7 +359,6 @@ class XCRemoteCacheConfigReader {
                 extraConfURL = URL(fileURLWithPath: config.extraConfigurationFile, relativeTo: rootURL)
             } catch {
                 infoLog("Extra config override failed with \(error). Skipping extra configuration")
-                break
             }
         }
 

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -83,6 +83,8 @@ public struct XCRemoteCacheConfig: Encodable {
     var downloadRetries: Int = 0
     /// Number of retries for upload requests
     var uploadRetries: Int = 3
+    /// Delay between retries
+    var retryDelay: Double = 10.0
     /// Extra headers appended to all remote HTTP(S) requests
     var requestCustomHeaders: [String: String] = [:]
     /// Filename (without an extension) of the compilation input file that is used

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -177,6 +177,7 @@ extension XCRemoteCacheConfig {
         merge.statsDir = scheme.statsDir ?? statsDir
         merge.downloadRetries = scheme.downloadRetries ?? downloadRetries
         merge.uploadRetries = scheme.uploadRetries ?? uploadRetries
+        merge.retryDelay = scheme.retryDelay ?? retryDelay
         merge.requestCustomHeaders = scheme.requestCustomHeaders ?? requestCustomHeaders
         merge.thinTargetMockFilename = scheme.thinTargetMockFilename ?? thinTargetMockFilename
         merge.focusedTargets = scheme.focusedTargets ?? focusedTargets
@@ -245,6 +246,7 @@ struct ConfigFileScheme: Decodable {
     let statsDir: String?
     let downloadRetries: Int?
     let uploadRetries: Int?
+    let retryDelay: Double?
     let requestCustomHeaders: [String: String]?
     let thinTargetMockFilename: String?
     let focusedTargets: [String]?
@@ -293,6 +295,7 @@ struct ConfigFileScheme: Decodable {
         case statsDir = "stats_dir"
         case downloadRetries = "download_retries"
         case uploadRetries = "upload_retries"
+        case retryDelay = "retry_delay"
         case requestCustomHeaders = "request_custom_headers"
         case thinTargetMockFilename = "thin_target_mock_filename"
         case focusedTargets = "focused_targets"

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -362,6 +362,8 @@ class XCRemoteCacheConfigReader {
                 extraConfURL = URL(fileURLWithPath: config.extraConfigurationFile, relativeTo: rootURL)
             } catch {
                 infoLog("Extra config override failed with \(error). Skipping extra configuration")
+                // swiftlint:disable:next unneeded_break_in_switch
+                break
             }
         }
 

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -83,7 +83,7 @@ public struct XCRemoteCacheConfig: Encodable {
     var downloadRetries: Int = 0
     /// Number of retries for upload requests
     var uploadRetries: Int = 3
-    /// Delay between retries
+    /// Delay between retries in seconds
     var retryDelay: Double = 10.0
     /// Extra headers appended to all remote HTTP(S) requests
     var requestCustomHeaders: [String: String] = [:]

--- a/Sources/XCRemoteCache/Network/NetworkClientImpl.swift
+++ b/Sources/XCRemoteCache/Network/NetworkClientImpl.swift
@@ -29,15 +29,15 @@ class NetworkClientImpl: NetworkClient {
     private let session: URLSession
     private let fileManager: FileManager
     private let maxRetries: Int
-    private let awsV4Signature: AWSV4Signature?
     private let retryDelay: TimeInterval
+    private let awsV4Signature: AWSV4Signature?
 
-    init(session: URLSession, retries: Int, fileManager: FileManager, awsV4Signature: AWSV4Signature?, retryDelay: TimeInterval = 30.0) {
+    init(session: URLSession, retries: Int, retryDelay: TimeInterval, fileManager: FileManager, awsV4Signature: AWSV4Signature?) {
         self.session = session
         self.fileManager = fileManager
-        maxRetries = retries
-        self.awsV4Signature = awsV4Signature
+        self.maxRetries = retries
         self.retryDelay = retryDelay
+        self.awsV4Signature = awsV4Signature
     }
 
     func fileExists(_ url: URL, completion: @escaping (Result<Bool, NetworkClientError>) -> Void) {

--- a/Sources/XCRemoteCache/Network/NetworkClientImpl.swift
+++ b/Sources/XCRemoteCache/Network/NetworkClientImpl.swift
@@ -30,12 +30,14 @@ class NetworkClientImpl: NetworkClient {
     private let fileManager: FileManager
     private let maxRetries: Int
     private let awsV4Signature: AWSV4Signature?
+    private let retryDelay: TimeInterval
 
-    init(session: URLSession, retries: Int, fileManager: FileManager, awsV4Signature: AWSV4Signature?) {
+    init(session: URLSession, retries: Int, fileManager: FileManager, awsV4Signature: AWSV4Signature?, retryDelay: TimeInterval = 30.0) {
         self.session = session
         self.fileManager = fileManager
         maxRetries = retries
         self.awsV4Signature = awsV4Signature
+        self.retryDelay = retryDelay
     }
 
     func fileExists(_ url: URL, completion: @escaping (Result<Bool, NetworkClientError>) -> Void) {
@@ -173,7 +175,7 @@ class NetworkClientImpl: NetworkClient {
             if let error = responseError {
                 if retries > 0 {
                     infoLog("Upload request failed with \(error). Left retries: \(retries).")
-                    self.makeUploadRequest(request, input: input, retries: retries - 1, completion: completion)
+                    self.retryUpload(request, input: input, retries: retries, completion: completion, after: self.retryDelay)
                     return
                 }
                 errorLog("Upload request failed: \(error)")
@@ -183,6 +185,13 @@ class NetworkClientImpl: NetworkClient {
             }
         }
         dataTask.resume()
+    }
+
+    private func retryUpload(_ request: URLRequest, input: URL, retries: Int, completion: @escaping (Result<Void, NetworkClientError>) -> Void, after: TimeInterval) {
+        DispatchQueue.global().asyncAfter(deadline: .now() + after) { [weak self] in
+            guard let self = self else { return }
+            self.makeUploadRequest(request, input: input, retries: retries - 1, completion: completion)
+        }
     }
 }
 

--- a/Sources/XCRemoteCache/Network/NetworkClientImpl.swift
+++ b/Sources/XCRemoteCache/Network/NetworkClientImpl.swift
@@ -175,7 +175,13 @@ class NetworkClientImpl: NetworkClient {
             if let error = responseError {
                 if retries > 0 {
                     infoLog("Upload request failed with \(error). Left retries: \(retries).")
-                    self.retryUpload(request, input: input, retries: retries, completion: completion, after: self.retryDelay)
+                    self.retryUpload(
+                        request,
+                        input: input,
+                        retries: retries,
+                        completion: completion,
+                        after: self.retryDelay
+                    )
                     return
                 }
                 errorLog("Upload request failed: \(error)")

--- a/Tests/XCRemoteCacheTests/Network/NetworkClientImplTests.swift
+++ b/Tests/XCRemoteCacheTests/Network/NetworkClientImplTests.swift
@@ -72,7 +72,7 @@ class NetworkClientImplTests: XCTestCase {
         configuration.protocolClasses = [URLProtocolStub.self]
         session = URLSession(configuration: configuration)
         fileManager = FileManager.default
-        client = NetworkClientImpl(session: session, retries: 0, fileManager: fileManager, awsV4Signature: nil)
+        client = NetworkClientImpl(session: session, retries: 0, retryDelay: 0, fileManager: fileManager, awsV4Signature: nil)
     }
 
     override func tearDown() {
@@ -141,7 +141,7 @@ class NetworkClientImplTests: XCTestCase {
     }
 
     func testUploadFilureWith400Retries() throws {
-        client = NetworkClientImpl(session: session, retries: 2, fileManager: fileManager, awsV4Signature: nil, retryDelay: 0.1)
+        client = NetworkClientImpl(session: session, retries: 2, retryDelay: 0.1, fileManager: fileManager, awsV4Signature: nil)
         responses[url] = .success(failureResponse, Data())
         _ = try waitForResponse({ client.upload(fileURL, as: url, completion: $0) }, timeout: 0.5)
 
@@ -153,7 +153,7 @@ class NetworkClientImplTests: XCTestCase {
     }
 
     func testUploadSuccessDoesntRetry() throws {
-        client = NetworkClientImpl(session: session, retries: 0, fileManager: fileManager, awsV4Signature: nil)
+        client = NetworkClientImpl(session: session, retries: 0, retryDelay: 0.1, fileManager: fileManager, awsV4Signature: nil)
         responses[url] = .success(successResponse, Data())
         _ = try waitForResponse { client.upload(fileURL, as: url, completion: $0) }
 
@@ -208,7 +208,7 @@ class NetworkClientImplTests: XCTestCase {
             service: "iam",
             date: Date(timeIntervalSince1970: 1_440_938_160)
         )
-        client = NetworkClientImpl(session: session, retries: 0, fileManager: fileManager, awsV4Signature: signature)
+        client = NetworkClientImpl(session: session, retries: 0, retryDelay: 0.1, fileManager: fileManager, awsV4Signature: signature)
         responses[url] = .success(successResponse, Data())
         _ = try waitForResponse { client.fetch(url, completion: $0) }
 

--- a/Tests/XCRemoteCacheTests/Network/NetworkClientImplTests.swift
+++ b/Tests/XCRemoteCacheTests/Network/NetworkClientImplTests.swift
@@ -72,7 +72,13 @@ class NetworkClientImplTests: XCTestCase {
         configuration.protocolClasses = [URLProtocolStub.self]
         session = URLSession(configuration: configuration)
         fileManager = FileManager.default
-        client = NetworkClientImpl(session: session, retries: 0, retryDelay: 0, fileManager: fileManager, awsV4Signature: nil)
+        client = NetworkClientImpl(
+            session: session,
+            retries: 0,
+            retryDelay: 0,
+            fileManager: fileManager,
+            awsV4Signature: nil
+        )
     }
 
     override func tearDown() {
@@ -141,7 +147,13 @@ class NetworkClientImplTests: XCTestCase {
     }
 
     func testUploadFilureWith400Retries() throws {
-        client = NetworkClientImpl(session: session, retries: 2, retryDelay: 0.1, fileManager: fileManager, awsV4Signature: nil)
+        client = NetworkClientImpl(
+            session: session,
+            retries: 2,
+            retryDelay: 0,
+            fileManager: fileManager,
+            awsV4Signature: nil
+        )
         responses[url] = .success(failureResponse, Data())
         _ = try waitForResponse({ client.upload(fileURL, as: url, completion: $0) }, timeout: 0.5)
 
@@ -153,7 +165,13 @@ class NetworkClientImplTests: XCTestCase {
     }
 
     func testUploadSuccessDoesntRetry() throws {
-        client = NetworkClientImpl(session: session, retries: 0, retryDelay: 0.1, fileManager: fileManager, awsV4Signature: nil)
+        client = NetworkClientImpl(
+            session: session,
+            retries: 0,
+            retryDelay: 0,
+            fileManager: fileManager,
+            awsV4Signature: nil
+        )
         responses[url] = .success(successResponse, Data())
         _ = try waitForResponse { client.upload(fileURL, as: url, completion: $0) }
 
@@ -208,7 +226,13 @@ class NetworkClientImplTests: XCTestCase {
             service: "iam",
             date: Date(timeIntervalSince1970: 1_440_938_160)
         )
-        client = NetworkClientImpl(session: session, retries: 0, retryDelay: 0.1, fileManager: fileManager, awsV4Signature: signature)
+        client = NetworkClientImpl(
+            session: session,
+            retries: 0,
+            retryDelay: 0,
+            fileManager: fileManager,
+            awsV4Signature: signature
+        )
         responses[url] = .success(successResponse, Data())
         _ = try waitForResponse { client.fetch(url, completion: $0) }
 

--- a/Tests/XCRemoteCacheTests/Network/NetworkClientImplTests.swift
+++ b/Tests/XCRemoteCacheTests/Network/NetworkClientImplTests.swift
@@ -87,7 +87,7 @@ class NetworkClientImplTests: XCTestCase {
         super.tearDown()
     }
 
-    func waitForResponse<R>(_ action: (@escaping Completion<R>) -> Void) throws -> Result<R, NetworkClientError> {
+    func waitForResponse<R>(_ action: (@escaping Completion<R>) -> Void, timeout: TimeInterval = 0.1) throws -> Result<R, NetworkClientError> {
         let responseExpectation = expectation(description: "RequestResponse")
         var receivedResponse: Result<R, NetworkClientError>?
 
@@ -95,7 +95,7 @@ class NetworkClientImplTests: XCTestCase {
             receivedResponse = response
             responseExpectation.fulfill()
         }
-        waitForExpectations(timeout: 0.1)
+        waitForExpectations(timeout: timeout)
         return try receivedResponse.unwrap()
     }
 
@@ -141,9 +141,9 @@ class NetworkClientImplTests: XCTestCase {
     }
 
     func testUploadFilureWith400Retries() throws {
-        client = NetworkClientImpl(session: session, retries: 2, fileManager: fileManager, awsV4Signature: nil)
+        client = NetworkClientImpl(session: session, retries: 2, fileManager: fileManager, awsV4Signature: nil, retryDelay: 0.1)
         responses[url] = .success(failureResponse, Data())
-        _ = try waitForResponse { client.upload(fileURL, as: url, completion: $0) }
+        _ = try waitForResponse({ client.upload(fileURL, as: url, completion: $0) }, timeout: 0.5)
 
         XCTAssertEqual(
             requests.map(\.url),


### PR DESCRIPTION
There was no delay between network request retries, so in case of some network problem there was not enough time to resolve it. For example, a network drop that will be automatically repaired in 30-40 seconds.
I added this to the configuration so that the user could define it.