### PR TITLE
Add upload_batch_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ _Note that for the `producer` mode, the prebuild build phase and `xccc`, `xcld`,
 | `download_retries` | Number of retries for download requests | `0` | ⬜️ |
 | `upload_retries` | Number of retries for upload requests | `3` | ⬜️ |
 | `retry_delay` | Delay between retries in seconds | `10` | ⬜️ |
-| `max_concurrent_requests` | Maximum number of simultaneous requests. 0 means no limits | `0` | ⬜️ |
+| `upload_batch_size` | Maximum number of simultaneous requests. 0 means no limits | `0` | ⬜️ |
 | `request_custom_headers` | Dictionary of extra HTTP headers for all remote server requests | `[]` | ⬜️ |
 | `thin_target_mock_filename` | Filename (without an extension) of the compilation input file that is used as a fake compilation for the forced-cached target (aka thin target) | `standin` | ⬜️ |
 | `focused_targets` | A list of all targets that are not thinned. If empty, all targets are meant to be non-thin | `[]` | ⬜️ |

--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ _Note that for the `producer` mode, the prebuild build phase and `xccc`, `xcld`,
 | `download_retries` | Number of retries for download requests | `0` | ⬜️ |
 | `upload_retries` | Number of retries for upload requests | `3` | ⬜️ |
 | `retry_delay` | Delay between retries in seconds | `10` | ⬜️ |
+| `max_concurrent_requests` | Maximum number of simultaneous requests. 0 means no limits | `0` | ⬜️ |
 | `request_custom_headers` | Dictionary of extra HTTP headers for all remote server requests | `[]` | ⬜️ |
 | `thin_target_mock_filename` | Filename (without an extension) of the compilation input file that is used as a fake compilation for the forced-cached target (aka thin target) | `standin` | ⬜️ |
 | `focused_targets` | A list of all targets that are not thinned. If empty, all targets are meant to be non-thin | `[]` | ⬜️ |

--- a/Rakefile
+++ b/Rakefile
@@ -72,6 +72,22 @@ task :build, [:configuration, :arch, :sdks, :is_archive] do |task, args|
   end
 end
 
+desc 'Build release artifacts'
+task :prepare_release do
+  system("rm -rf releases && rm -rf tmp")
+  Rake::Task['build'].invoke("release", "x86_64-apple-macosx")
+  system("mkdir -p tmp && unzip releases/XCRemoteCache.zip -d tmp/xcremotecache-x86_64")
+  system("rm -rf releases")
+  Rake::Task['build'].invoke("release", "arm64-apple-macosx")
+  system("rake 'build[release, arm64-apple-macosx]'")
+  system("mkdir -p tmp && unzip releases/XCRemoteCache.zip -d tmp/xcremotecache-arm64")
+  system("rm -rf releases")
+  system("mkdir -p releases && zip -jr releases/XCRemoteCache-macOS-x86_64.zip LICENSE README.md tmp/xcremotecache-x86_64")
+  system("zip -jr releases/XCRemoteCache-macOS-arm64.zip LICENSE README.md tmp/xcremotecache-arm64")
+  system("mkdir -p tmp/xcremotecache && ls tmp/xcremotecache-x86_64 | xargs -I {} lipo -create -output tmp/xcremotecache/{} tmp/xcremotecache-x86_64/{} tmp/xcremotecache-arm64/{}")
+  system("zip -jr releases/XCRemoteCache-macOS-arm64-x86_64.zip LICENSE README.md tmp/xcremotecache")
+end
+
 desc 'run tests with SPM'
 task :test do
   # Running tests

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -131,6 +131,7 @@ public class XCPostbuild {
                 mode: context.mode,
                 downloadStreamURL: context.recommendedCacheAddress,
                 upstreamStreamURL: context.cacheAddresses,
+                maxConcurrentRequests: config.maxConcurrentRequests,
                 networkClient: networkClient,
                 urlBuilderFactory: {
                     try URLBuilderImpl(

--- a/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/XCPostbuild.swift
@@ -131,7 +131,7 @@ public class XCPostbuild {
                 mode: context.mode,
                 downloadStreamURL: context.recommendedCacheAddress,
                 upstreamStreamURL: context.cacheAddresses,
-                maxConcurrentRequests: config.maxConcurrentRequests,
+                uploadBatchSize: config.uploadBatchSize,
                 networkClient: networkClient,
                 urlBuilderFactory: {
                     try URLBuilderImpl(

--- a/Sources/XCRemoteCache/Commands/Prepare/XCPrepareMark.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/XCPrepareMark.swift
@@ -77,7 +77,7 @@ public class XCPrepareMark {
                 mode: .producer,
                 downloadStreamURL: context.recommendedCacheAddress,
                 upstreamStreamURL: context.cacheAddresses,
-                maxConcurrentRequests: config.maxConcurrentRequests,
+                uploadBatchSize: config.uploadBatchSize,
                 networkClient: networkClient
             ) { [configuration, platform] cacheAddress in
                 // Prepare URLs don't include target name or envFingperint, which are valid only for a target level

--- a/Sources/XCRemoteCache/Commands/Prepare/XCPrepareMark.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/XCPrepareMark.swift
@@ -77,6 +77,7 @@ public class XCPrepareMark {
                 mode: .producer,
                 downloadStreamURL: context.recommendedCacheAddress,
                 upstreamStreamURL: context.cacheAddresses,
+                maxConcurrentRequests: config.maxConcurrentRequests,
                 networkClient: networkClient
             ) { [configuration, platform] cacheAddress in
                 // Prepare URLs don't include target name or envFingperint, which are valid only for a target level

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -85,6 +85,8 @@ public struct XCRemoteCacheConfig: Encodable {
     var uploadRetries: Int = 3
     /// Delay between retries in seconds
     var retryDelay: Double = 10.0
+    /// Maximum number of simultaneous requests. 0 means no limits
+    var maxConcurrentRequests: Int = 0
     /// Extra headers appended to all remote HTTP(S) requests
     var requestCustomHeaders: [String: String] = [:]
     /// Filename (without an extension) of the compilation input file that is used
@@ -178,6 +180,7 @@ extension XCRemoteCacheConfig {
         merge.downloadRetries = scheme.downloadRetries ?? downloadRetries
         merge.uploadRetries = scheme.uploadRetries ?? uploadRetries
         merge.retryDelay = scheme.retryDelay ?? retryDelay
+        merge.maxConcurrentRequests = scheme.maxConcurrentRequests ?? maxConcurrentRequests
         merge.requestCustomHeaders = scheme.requestCustomHeaders ?? requestCustomHeaders
         merge.thinTargetMockFilename = scheme.thinTargetMockFilename ?? thinTargetMockFilename
         merge.focusedTargets = scheme.focusedTargets ?? focusedTargets
@@ -247,6 +250,7 @@ struct ConfigFileScheme: Decodable {
     let downloadRetries: Int?
     let uploadRetries: Int?
     let retryDelay: Double?
+    let maxConcurrentRequests: Int?
     let requestCustomHeaders: [String: String]?
     let thinTargetMockFilename: String?
     let focusedTargets: [String]?
@@ -296,6 +300,7 @@ struct ConfigFileScheme: Decodable {
         case downloadRetries = "download_retries"
         case uploadRetries = "upload_retries"
         case retryDelay = "retry_delay"
+        case maxConcurrentRequests = "max_concurrent_requests"
         case requestCustomHeaders = "request_custom_headers"
         case thinTargetMockFilename = "thin_target_mock_filename"
         case focusedTargets = "focused_targets"

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -86,7 +86,7 @@ public struct XCRemoteCacheConfig: Encodable {
     /// Delay between retries in seconds
     var retryDelay: Double = 10.0
     /// Maximum number of simultaneous requests. 0 means no limits
-    var maxConcurrentRequests: Int = 0
+    var uploadBatchSize: Int = 0
     /// Extra headers appended to all remote HTTP(S) requests
     var requestCustomHeaders: [String: String] = [:]
     /// Filename (without an extension) of the compilation input file that is used
@@ -180,7 +180,7 @@ extension XCRemoteCacheConfig {
         merge.downloadRetries = scheme.downloadRetries ?? downloadRetries
         merge.uploadRetries = scheme.uploadRetries ?? uploadRetries
         merge.retryDelay = scheme.retryDelay ?? retryDelay
-        merge.maxConcurrentRequests = scheme.maxConcurrentRequests ?? maxConcurrentRequests
+        merge.uploadBatchSize = scheme.uploadBatchSize ?? uploadBatchSize
         merge.requestCustomHeaders = scheme.requestCustomHeaders ?? requestCustomHeaders
         merge.thinTargetMockFilename = scheme.thinTargetMockFilename ?? thinTargetMockFilename
         merge.focusedTargets = scheme.focusedTargets ?? focusedTargets
@@ -250,7 +250,7 @@ struct ConfigFileScheme: Decodable {
     let downloadRetries: Int?
     let uploadRetries: Int?
     let retryDelay: Double?
-    let maxConcurrentRequests: Int?
+    let uploadBatchSize: Int?
     let requestCustomHeaders: [String: String]?
     let thinTargetMockFilename: String?
     let focusedTargets: [String]?
@@ -300,7 +300,7 @@ struct ConfigFileScheme: Decodable {
         case downloadRetries = "download_retries"
         case uploadRetries = "upload_retries"
         case retryDelay = "retry_delay"
-        case maxConcurrentRequests = "max_concurrent_requests"
+        case uploadBatchSize = "upload_batch_size"
         case requestCustomHeaders = "request_custom_headers"
         case thinTargetMockFilename = "thin_target_mock_filename"
         case focusedTargets = "focused_targets"

--- a/Sources/XCRemoteCache/Network/RemoteNetworkClientAbstractFactory.swift
+++ b/Sources/XCRemoteCache/Network/RemoteNetworkClientAbstractFactory.swift
@@ -27,11 +27,20 @@ class RemoteNetworkClientAbstractFactory {
     private let upstreamStreamURL: [URL]
     private let networkClient: NetworkClient
     private let urlBuilderFactory: (URL) throws -> URLBuilder
+    private let maxConcurrentRequests: Int
 
-    init(mode: Mode, downloadStreamURL: URL, upstreamStreamURL: [URL], networkClient: NetworkClient, urlBuilderFactory: @escaping (URL) throws -> URLBuilder) {
+    init(
+        mode: Mode,
+        downloadStreamURL: URL,
+        upstreamStreamURL: [URL],
+        maxConcurrentRequests: Int,
+        networkClient: NetworkClient,
+        urlBuilderFactory: @escaping (URL) throws -> URLBuilder
+    ) {
         self.mode = mode
         self.downloadStreamURL = downloadStreamURL
         self.upstreamStreamURL = upstreamStreamURL
+        self.maxConcurrentRequests = maxConcurrentRequests
         self.networkClient = networkClient
         self.urlBuilderFactory = urlBuilderFactory
     }
@@ -49,7 +58,8 @@ class RemoteNetworkClientAbstractFactory {
             return ReplicatedRemotesNetworkClient(
                 networkClient,
                 download: downloadURLBuilder,
-                uploads: upstreamBuilders
+                uploads: upstreamBuilders,
+                maxConcurrentRequests: maxConcurrentRequests
             )
         case .consumer:
             return RemoteNetworkClientImpl(networkClient, downloadURLBuilder)

--- a/Sources/XCRemoteCache/Network/RemoteNetworkClientAbstractFactory.swift
+++ b/Sources/XCRemoteCache/Network/RemoteNetworkClientAbstractFactory.swift
@@ -27,20 +27,20 @@ class RemoteNetworkClientAbstractFactory {
     private let upstreamStreamURL: [URL]
     private let networkClient: NetworkClient
     private let urlBuilderFactory: (URL) throws -> URLBuilder
-    private let maxConcurrentRequests: Int
+    private let uploadBatchSize: Int
 
     init(
         mode: Mode,
         downloadStreamURL: URL,
         upstreamStreamURL: [URL],
-        maxConcurrentRequests: Int,
+        uploadBatchSize: Int,
         networkClient: NetworkClient,
         urlBuilderFactory: @escaping (URL) throws -> URLBuilder
     ) {
         self.mode = mode
         self.downloadStreamURL = downloadStreamURL
         self.upstreamStreamURL = upstreamStreamURL
-        self.maxConcurrentRequests = maxConcurrentRequests
+        self.uploadBatchSize = uploadBatchSize
         self.networkClient = networkClient
         self.urlBuilderFactory = urlBuilderFactory
     }
@@ -59,7 +59,7 @@ class RemoteNetworkClientAbstractFactory {
                 networkClient,
                 download: downloadURLBuilder,
                 uploads: upstreamBuilders,
-                maxConcurrentRequests: maxConcurrentRequests
+                uploadBatchSize: uploadBatchSize
             )
         case .consumer:
             return RemoteNetworkClientImpl(networkClient, downloadURLBuilder)

--- a/Sources/XCRemoteCache/Network/ReplicatedRemotesNetworkClient.swift
+++ b/Sources/XCRemoteCache/Network/ReplicatedRemotesNetworkClient.swift
@@ -23,12 +23,12 @@ import Foundation
 class ReplicatedRemotesNetworkClient: RemoteNetworkClientImpl {
     private let networkClient: NetworkClient
     private let uploadURLBuilders: [URLBuilder]
-    private let maxConcurrentRequests: Int
+    private let uploadBatchSize: Int
 
-    init(_ networkClient: NetworkClient, download: URLBuilder, uploads uploadURLBuilders: [URLBuilder], maxConcurrentRequests: Int) {
+    init(_ networkClient: NetworkClient, download: URLBuilder, uploads uploadURLBuilders: [URLBuilder], uploadBatchSize: Int) {
         self.networkClient = networkClient
         self.uploadURLBuilders = uploadURLBuilders
-        self.maxConcurrentRequests = maxConcurrentRequests
+        self.uploadBatchSize = uploadBatchSize
         super.init(networkClient, download)
     }
 
@@ -41,7 +41,7 @@ class ReplicatedRemotesNetworkClient: RemoteNetworkClientImpl {
         let group = DispatchGroup()
         var results: [Result<Void, NetworkClientError>] = Array(repeating: .failure(.noResponse), count: urls.count)
         urls.enumerated().forEach { index, url in
-            if maxConcurrentRequests > 0 && index > 0 && index % maxConcurrentRequests == 0 {
+            if uploadBatchSize > 0 && index > 0 && index % uploadBatchSize == 0 {
                 group.wait()
             }
             group.enter()
@@ -63,7 +63,7 @@ class ReplicatedRemotesNetworkClient: RemoteNetworkClientImpl {
         let group = DispatchGroup()
         var results: [Result<Void, NetworkClientError>] = Array(repeating: .failure(.noResponse), count: urls.count)
         urls.enumerated().forEach { index, url in
-            if maxConcurrentRequests > 0 && index > 0 && index % maxConcurrentRequests == 0 {
+            if uploadBatchSize > 0 && index > 0 && index % uploadBatchSize == 0 {
                 group.wait()
             }
             group.enter()

--- a/Tests/XCRemoteCacheTests/Config/XCRemoteCacheConfigReaderTests.swift
+++ b/Tests/XCRemoteCacheTests/Config/XCRemoteCacheConfigReaderTests.swift
@@ -32,11 +32,18 @@ class XCRemoteCacheConfigReaderTests: XCTestCase {
     }
 
     func testReadsFromExtraConfig() throws {
-        try fileReader.write(toPath: "/.rcinfo", contents: "cache_addresses: [test]")
+        let contents = [
+            "cache_addresses: [test]",
+            "retry_delay: 30",
+            "upload_batch_size: 5",
+        ].joined(separator: "\n").data(using: .utf8)
+        try fileReader.write(toPath: "/.rcinfo", contents: contents)
 
         let config = try reader.readConfiguration()
 
         XCTAssertEqual(config.cacheAddresses, ["test"])
+        XCTAssertEqual(config.retryDelay, 30)
+        XCTAssertEqual(config.uploadBatchSize, 5)
     }
 
     func testOverridesExtraConfigFromExtraFile() throws {

--- a/Tests/XCRemoteCacheTests/Network/ReplicatedRemotesNetworkClientTests.swift
+++ b/Tests/XCRemoteCacheTests/Network/ReplicatedRemotesNetworkClientTests.swift
@@ -43,7 +43,7 @@ class ReplicatedRemotesNetworkClientTests: XCTestCase {
             networkClient,
             download: download,
             uploads: uploads,
-            maxConcurrentRequests: 1
+            uploadBatchSize: 1
         )
     }
 
@@ -81,7 +81,7 @@ class ReplicatedRemotesNetworkClientTests: XCTestCase {
             networkClient,
             download: download,
             uploads: uploads,
-            maxConcurrentRequests: 10
+            uploadBatchSize: 10
         )
 
         try client.uploadSynchronously(localSampleFile, as: .artifact(id: "id1"))


### PR DESCRIPTION
I added a new configuration parameter - upload_batch_size, to limit the number of concurrent requests.
There were no limitations before, and performing a large number of parallel requests can cause problems with the network, which even with the retry logic may not be recoverable.