### PR TITLE
Make PUBLIC_HEADERS_FOLDER_PATH ENV optional

### DIFF
--- a/Sources/XCRemoteCache/Commands/Postbuild/PostbuildContext.swift
+++ b/Sources/XCRemoteCache/Commands/Postbuild/PostbuildContext.swift
@@ -140,8 +140,8 @@ extension PostbuildContext {
         /// Note: The file has yaml extension, even it is in the json format
         overlayHeadersPath = targetTempDir.appendingPathComponent("all-product-headers.yaml")
         irrelevantDependenciesPaths = config.irrelevantDependenciesPaths
-        let publicHeadersPath: String = try env.readEnv(key: "PUBLIC_HEADERS_FOLDER_PATH")
-        if publicHeadersPath != "/usr/local/include" {
+        let publicHeadersPathEnv: String? = env.readEnv(key: "PUBLIC_HEADERS_FOLDER_PATH")
+        if let publicHeadersPath = publicHeadersPathEnv, publicHeadersPathEnv != "/usr/local/include" {
             // '/usr/local/include' is a value of PUBLIC_HEADERS_FOLDER_PATH when no public headers are automatically
             // generated and it is up to a project configuration to place it in a common location (e.g. static library)
             publicHeadersFolderPath = builtProductsDir.appendingPathComponent(publicHeadersPath)

--- a/Tests/XCRemoteCacheTests/Commands/PostbuildContextTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/PostbuildContextTests.swift
@@ -150,4 +150,13 @@ class PostbuildContextTests: FileXCTestCase {
 
         XCTAssertEqual(context.publicHeadersFolderPath, "/MyBuiltProductsDir/MyModule.grameworks/Headers")
     }
+    
+    func testPublicHeaderFolderPathEnvIsOptional() throws {
+        var envs = Self.SampleEnvs
+        envs.removeValue(forKey: "PUBLIC_HEADERS_FOLDER_PATH")
+
+        let context = try PostbuildContext(config, env: envs)
+
+        XCTAssertNil(context.publicHeadersFolderPath)
+    }
 }

--- a/Tests/XCRemoteCacheTests/Commands/PostbuildContextTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/PostbuildContextTests.swift
@@ -150,7 +150,7 @@ class PostbuildContextTests: FileXCTestCase {
 
         XCTAssertEqual(context.publicHeadersFolderPath, "/MyBuiltProductsDir/MyModule.grameworks/Headers")
     }
-    
+
     func testPublicHeaderFolderPathEnvIsOptional() throws {
         var envs = Self.SampleEnvs
         envs.removeValue(forKey: "PUBLIC_HEADERS_FOLDER_PATH")


### PR DESCRIPTION
According to #163, `PUBLIC_HEADERS_FOLDER_PATH` introduced in #149 is not always available - e.g. when CocoaPods build a static library. _For a CocoaPods scenario, take a look on the sourcecode [here](https://github.com/CocoaPods/CocoaPods/blob/47532a0f04b0267fdfc3bfc9aa1e5db401c5c92a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb#L217) and note that when a Build Setting is set to an empty string, a build phase script is called without that ENV_. 

In such a case, we don't have to automatically rewrite generated `-Swift.h` file. To skip the rewriting step (introduced in #149) we can leave `publicHeadersFolderPath` as `nil`.

The original issue (#149) reports that this problem is caused only when a static library is used (not frameworks).

Fixes #163