### PR TITLE
Add spotify OSS maintainer metadata

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,7 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: XCRemoteCache
+spec:
+  type: library
+  owner: foundation


### PR DESCRIPTION
`catalog-info.yaml` is needed to internally track who owns this open-source project.