### PR TITLE
Add SPI files: private.swiftinterface and abi.json

### DIFF
--- a/Sources/XCRemoteCache/Artifacts/SwiftmoduleFileExtension.swift
+++ b/Sources/XCRemoteCache/Artifacts/SwiftmoduleFileExtension.swift
@@ -31,6 +31,8 @@ enum SwiftmoduleFileExtension: String {
     case swiftdoc
     case swiftsourceinfo
     case swiftinterface
+    case privateSwiftinterface
+    case abiJson
 }
 
 extension SwiftmoduleFileExtension {
@@ -40,5 +42,7 @@ extension SwiftmoduleFileExtension {
         .swiftdoc: .required,
         .swiftsourceinfo: .optional,
         .swiftinterface: .optional,
+        .privateSwiftinterface: .optional,
+        .abiJson: .optional,
     ]
 }

--- a/Sources/XCRemoteCache/Artifacts/SwiftmoduleFileExtension.swift
+++ b/Sources/XCRemoteCache/Artifacts/SwiftmoduleFileExtension.swift
@@ -31,8 +31,8 @@ enum SwiftmoduleFileExtension: String {
     case swiftdoc
     case swiftsourceinfo
     case swiftinterface
-    case privateSwiftinterface
-    case abiJson
+    case privateSwiftinterface = "private.swiftinterface"
+    case abiJson = "abi.json"
 }
 
 extension SwiftmoduleFileExtension {

--- a/Tests/XCRemoteCacheTests/Artifacts/ArtifactSwiftProductsBuilderImplTests.swift
+++ b/Tests/XCRemoteCacheTests/Artifacts/ArtifactSwiftProductsBuilderImplTests.swift
@@ -28,6 +28,8 @@ class ArtifactSwiftProductsBuilderImplTests: FileXCTestCase {
     private var swiftmoduleDocFile: URL!
     private var swiftmoduleSourceInfoFile: URL!
     private var swiftmoduleInterfaceFile: URL!
+    private var privateSwiftmoduleInterfaceFile: URL!
+    private var abiJsonFile: URL!
     private var workingDir: URL!
     private var builder: ArtifactSwiftProductsBuilderImpl!
 
@@ -39,6 +41,9 @@ class ArtifactSwiftProductsBuilderImplTests: FileXCTestCase {
         swiftmoduleDocFile = moduleDir.appendingPathComponent("MyModule.swiftdoc")
         swiftmoduleSourceInfoFile = moduleDir.appendingPathComponent("MyModule.swiftsourceinfo")
         swiftmoduleInterfaceFile = moduleDir.appendingPathComponent("MyModule.swiftinterface")
+        privateSwiftmoduleInterfaceFile = moduleDir.appendingPathComponent("MyModule.private.swiftinterface")
+        abiJsonFile = moduleDir.appendingPathComponent("MyModule.abi.json")
+
         workingDir = rootDir.appendingPathComponent("working")
         builder = ArtifactSwiftProductsBuilderImpl(
             workingDir: workingDir,
@@ -98,6 +103,8 @@ class ArtifactSwiftProductsBuilderImplTests: FileXCTestCase {
         try fileManager.spt_createEmptyFile(swiftmoduleDocFile)
         try fileManager.spt_createEmptyFile(swiftmoduleSourceInfoFile)
         try fileManager.spt_createEmptyFile(swiftmoduleInterfaceFile)
+        try fileManager.spt_createEmptyFile(privateSwiftmoduleInterfaceFile)
+        try fileManager.spt_createEmptyFile(abiJsonFile)
         let builderSwiftmoduleDir =
             builder
                 .buildingArtifactSwiftModulesLocation()
@@ -110,6 +117,10 @@ class ArtifactSwiftProductsBuilderImplTests: FileXCTestCase {
             builderSwiftmoduleDir.appendingPathComponent("MyModule.swiftsourceinfo")
         let expectedBuildedSwiftInterfaceFile =
             builderSwiftmoduleDir.appendingPathComponent("MyModule.swiftinterface")
+        let expectedPrivateSwiftmoduleInterfaceFile =
+            builderSwiftmoduleDir.appendingPathComponent("MyModule.private.swiftinterface")
+        let expectedAbiJsonFile =
+            builderSwiftmoduleDir.appendingPathComponent("MyModule.abi.json")
 
         try builder.includeModuleDefinitionsToTheArtifact(arch: "arm64", moduleURL: swiftmoduleFile)
 
@@ -117,6 +128,8 @@ class ArtifactSwiftProductsBuilderImplTests: FileXCTestCase {
         XCTAssertTrue(fileManager.fileExists(atPath: expectedBuildedSwiftmoduledocFile.path))
         XCTAssertTrue(fileManager.fileExists(atPath: expectedBuildedSwiftSourceInfoFile.path))
         XCTAssertTrue(fileManager.fileExists(atPath: expectedBuildedSwiftInterfaceFile.path))
+        XCTAssertTrue(fileManager.fileExists(atPath: expectedPrivateSwiftmoduleInterfaceFile.path))
+        XCTAssertTrue(fileManager.fileExists(atPath: expectedAbiJsonFile.path))
     }
 
     func testFailsIncludingWhenMissingRequiredSwiftmoduleFiles() throws {

--- a/Tests/XCRemoteCacheTests/Artifacts/BuildArtifactCreatorTests.swift
+++ b/Tests/XCRemoteCacheTests/Artifacts/BuildArtifactCreatorTests.swift
@@ -32,6 +32,8 @@ class BuildArtifactCreatorTests: FileXCTestCase {
     private var swiftdocURL: URL!
     private var swiftSourceInfoURL: URL!
     private var swiftInterfaceURL: URL!
+    private var privateSwiftInterfaceURL: URL!
+    private var abiJsonURL: URL!
     private var executablePath: String!
     private var executableURL: URL!
     private var creator: BuildArtifactCreator!
@@ -53,6 +55,10 @@ class BuildArtifactCreatorTests: FileXCTestCase {
             .appendingPathComponent("Target.swiftsourceinfo")
         swiftInterfaceURL = workDirectory.appendingPathComponent("Objects-normal")
             .appendingPathComponent("Target.swiftinterface")
+        privateSwiftInterfaceURL = workDirectory.appendingPathComponent("Objects-normal")
+            .appendingPathComponent("Target.private.swiftinterface")
+        abiJsonURL = workDirectory.appendingPathComponent("Objects-normal")
+            .appendingPathComponent("Target.abi.json")
         executablePath = "libTarget.a"
         executableURL = buildDir.appendingPathComponent(executablePath)
         dSYM = executableURL.deletingPathExtension().appendingPathExtension(".dSYM")
@@ -124,6 +130,8 @@ class BuildArtifactCreatorTests: FileXCTestCase {
         try fileManager.spt_createEmptyFile(swiftdocURL)
         try fileManager.spt_createEmptyFile(swiftSourceInfoURL)
         try fileManager.spt_createEmptyFile(swiftInterfaceURL)
+        try fileManager.spt_createEmptyFile(privateSwiftInterfaceURL)
+        try fileManager.spt_createEmptyFile(abiJsonURL)
 
         try creator.includeModuleDefinitionsToTheArtifact(arch: "arch", moduleURL: swiftmoduleURL)
         let artifact = try creator.createArtifact(artifactKey: "key", meta: sampleMeta)
@@ -138,6 +146,8 @@ class BuildArtifactCreatorTests: FileXCTestCase {
             unzippedURL.appendingPathComponent("swiftmodule/arch/Target.swiftdoc"),
             unzippedURL.appendingPathComponent("swiftmodule/arch/Target.swiftsourceinfo"),
             unzippedURL.appendingPathComponent("swiftmodule/arch/Target.swiftinterface"),
+            unzippedURL.appendingPathComponent("swiftmodule/arch/Target.private.swiftinterface"),
+            unzippedURL.appendingPathComponent("swiftmodule/arch/Target.abi.json"),
         ])
     }
 

--- a/Tests/XCRemoteCacheTests/Commands/SwiftcTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/SwiftcTests.swift
@@ -311,21 +311,14 @@ class SwiftcTests: FileXCTestCase {
         _ = try swiftc.mockCompilation()
 
         let swiftModuleFiles = try productsGenerator.generated.first.unwrap()
-        let swiftModuleURL = swiftModuleFiles.0[.swiftmodule]
-        let swiftDocURL = swiftModuleFiles.0[.swiftdoc]
-        let swiftSourceInfoURL = swiftModuleFiles.0[.swiftsourceinfo]
-        let swiftInterfaceURL = swiftModuleFiles.0[.swiftinterface]
-        let privateSwiftInterfaceURL = swiftModuleFiles.0[.privateSwiftinterface]
-        let abiJsonURL = swiftModuleFiles.0[.abiJson]
-        let swiftHeaderURL = swiftModuleFiles.1
 
-        XCTAssertEqual(swiftModuleURL, artifactSwiftmodule)
-        XCTAssertEqual(swiftDocURL, artifactSwiftdoc)
-        XCTAssertEqual(swiftSourceInfoURL, artifactSwiftSourceInfo)
-        XCTAssertEqual(swiftHeaderURL, artifactObjCHeader)
-        XCTAssertEqual(swiftInterfaceURL, artifactSwiftInterfaceInfo)
-        XCTAssertEqual(privateSwiftInterfaceURL, artifactPrivateSwiftInterfaceInfo)
-        XCTAssertEqual(abiJsonURL, artifactAbiJsonInfo)
+        XCTAssertEqual(swiftModuleFiles.0[.swiftmodule], artifactSwiftmodule)
+        XCTAssertEqual(swiftModuleFiles.0[.swiftdoc], artifactSwiftdoc)
+        XCTAssertEqual(swiftModuleFiles.0[.swiftsourceinfo], artifactSwiftSourceInfo)
+        XCTAssertEqual(swiftModuleFiles.0[.swiftinterface], artifactSwiftInterfaceInfo)
+        XCTAssertEqual(swiftModuleFiles.0[.privateSwiftinterface], artifactPrivateSwiftInterfaceInfo)
+        XCTAssertEqual(swiftModuleFiles.0[.abiJson], artifactAbiJsonInfo)
+        XCTAssertEqual(swiftModuleFiles.1, artifactObjCHeader)
     }
 
 

--- a/Tests/XCRemoteCacheTests/Commands/SwiftcTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/SwiftcTests.swift
@@ -285,6 +285,12 @@ class SwiftcTests: FileXCTestCase {
         let artifactSwiftInterfaceInfo = URL(
             fileURLWithPath: "/cachedArtifact/swiftmodule/archTest/Target.swiftinterface"
         )
+        let artifactPrivateSwiftInterfaceInfo = URL(
+            fileURLWithPath: "/cachedArtifact/swiftmodule/archTest/Target.private.swiftinterface"
+        )
+        let artifactAbiJsonInfo = URL(
+            fileURLWithPath: "/cachedArtifact/swiftmodule/archTest/Target.abi.json"
+        )
 
         artifactOrganizer = ArtifactOrganizerFake(artifactRoot: artifactRoot)
         let swiftc = Swiftc(
@@ -309,6 +315,8 @@ class SwiftcTests: FileXCTestCase {
         let swiftDocURL = swiftModuleFiles.0[.swiftdoc]
         let swiftSourceInfoURL = swiftModuleFiles.0[.swiftsourceinfo]
         let swiftInterfaceURL = swiftModuleFiles.0[.swiftinterface]
+        let privateSwiftInterfaceURL = swiftModuleFiles.0[.privateSwiftinterface]
+        let abiJsonURL = swiftModuleFiles.0[.abiJson]
         let swiftHeaderURL = swiftModuleFiles.1
 
         XCTAssertEqual(swiftModuleURL, artifactSwiftmodule)
@@ -316,6 +324,8 @@ class SwiftcTests: FileXCTestCase {
         XCTAssertEqual(swiftSourceInfoURL, artifactSwiftSourceInfo)
         XCTAssertEqual(swiftHeaderURL, artifactObjCHeader)
         XCTAssertEqual(swiftInterfaceURL, artifactSwiftInterfaceInfo)
+        XCTAssertEqual(privateSwiftInterfaceURL, artifactPrivateSwiftInterfaceInfo)
+        XCTAssertEqual(abiJsonURL, artifactAbiJsonInfo)
     }
 
 


### PR DESCRIPTION
Captures optional `.private.swiftinterface` and `.abi.json` that are generated for Swift's evolution mode with Xcode 14 by default. This 2 files are optional (just like .swiftinterface) and for non-evolution builds does not exist in the generated module.

Fixes #173