### PR TITLE
Compile locally PCH for c-header

### DIFF
--- a/Sources/XCRemoteCache/Commands/Prepare/CCWrapperBuilder.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/CCWrapperBuilder.swift
@@ -396,7 +396,8 @@ class TemplateBasedCCWrapperBuilder: CCWrapperBuilder {
             const char *output_arg_name = "-o";
             const char *serialize_diagnostics_arg_name = "--serialize-diagnostics";
             const char *language_mode_arg_name = "-x";
-            const char *precompile_header_arg_value = "objective-c-header";
+            const char *precompile_objc_header_arg_value = "objective-c-header";
+            const char *precompile_c_header_arg_value = "c-header";
             const char *clang_cmd = "\(clangCommand)";
             const char *markerFile = "\(markerFilename)";
             const char *compilationHistoryFile = "\(compilationHistoryFilename)";
@@ -464,7 +465,7 @@ class TemplateBasedCCWrapperBuilder: CCWrapperBuilder {
            clang_args[argc] = NULL;
 
            // Verify mode. Even a target is cached, pch mode is not supported. Fallback to the local compilation
-           if (language_mode != NULL && strcmp(language_mode, precompile_header_arg_value) == 0) {
+           if (language_mode != NULL && (strcmp(language_mode, precompile_objc_header_arg_value) == 0 || strcmp(language_mode, precompile_c_header_arg_value) == 0)) {
                return execvp(clang_cmd, (char *const*) clang_args);
            }
 

--- a/Tests/XCRemoteCacheTests/Commands/XCCCTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/XCCCTests.swift
@@ -343,7 +343,7 @@ class TemplateBasedCCWrapperBuilderTests: FileXCTestCase {
 
         XCTAssertTrue(fileManager.fileExists(atPath: outputFile.path))
     }
-    
+
     func testPCHCCompilationFallbacks() throws {
         // Marker is empty to mimic the new file scenario
         let pchFile = directory.appendingPathComponent("input.pch")

--- a/Tests/XCRemoteCacheTests/Commands/XCCCTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/XCCCTests.swift
@@ -333,11 +333,22 @@ class TemplateBasedCCWrapperBuilderTests: FileXCTestCase {
         XCTAssertNotEqual(newFileOutputData, Data())
     }
 
-    func testPCHCompilationFallbacks() throws {
+    func testPCHObjCCompilationFallbacks() throws {
         // Marker is empty to mimic the new file scenario
         let pchFile = directory.appendingPathComponent("input.pch")
         createValidPCHFile(pchFile)
         arguments = ["-x", "objective-c-header", "-MF", dependencyFile.path, "-o", outputFile.path, pchFile.path]
+
+        try shellExec(Self.xccc.path, args: arguments, inDir: directory.path)
+
+        XCTAssertTrue(fileManager.fileExists(atPath: outputFile.path))
+    }
+    
+    func testPCHCCompilationFallbacks() throws {
+        // Marker is empty to mimic the new file scenario
+        let pchFile = directory.appendingPathComponent("input.pch")
+        createValidPCHFile(pchFile)
+        arguments = ["-x", "c-header", "-MF", dependencyFile.path, "-o", outputFile.path, pchFile.path]
 
         try shellExec(Self.xccc.path, args: arguments, inDir: directory.path)
 


### PR DESCRIPTION
It has been reported that Xcode 14 precompiles pch for c headers and the same logic should be applied as for `objective-c-header`. This PR copies the same logic for `c-header`.

Fixes #37