### PR TITLE
Add LDPLUSPLUS in automatic integration mode

### DIFF
--- a/Sources/XCRemoteCache/Commands/Prepare/Integrate/BuildSettingsIntegrateAppender.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/Integrate/BuildSettingsIntegrateAppender.swift
@@ -50,6 +50,7 @@ class XcodeProjBuildSettingsIntegrateAppender: BuildSettingsIntegrateAppender {
             result["CC"] = wrappers.cc.path
             result["LD"] = wrappers.ld.path
             result["LIBTOOL"] = wrappers.libtool.path
+            result["LDPLUSPLUS"] = wrappers.ldplusplus.path
         }
 
         let existingSwiftFlags = result["OTHER_SWIFT_FLAGS"] as? String

--- a/Tests/XCRemoteCacheTests/Commands/Prepare/Integrate/XcodeProjBuildSettingsIntegrateAppenderTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/Prepare/Integrate/XcodeProjBuildSettingsIntegrateAppenderTests.swift
@@ -60,7 +60,7 @@ class XcodeProjBuildSettingsIntegrateAppenderTests: XCTestCase {
 
         XCTAssertEqual(resultURL, fakeRootURL.path)
     }
-    
+
     func testConsumerSettingLdPlusPlus() throws {
         let mode: Mode = .consumer
         let fakeRootURL: URL = "/xxxxxxxxxxC"

--- a/Tests/XCRemoteCacheTests/Commands/Prepare/Integrate/XcodeProjBuildSettingsIntegrateAppenderTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/Prepare/Integrate/XcodeProjBuildSettingsIntegrateAppenderTests.swift
@@ -60,4 +60,14 @@ class XcodeProjBuildSettingsIntegrateAppenderTests: XCTestCase {
 
         XCTAssertEqual(resultURL, fakeRootURL.path)
     }
+    
+    func testConsumerSettingLdPlusPlus() throws {
+        let mode: Mode = .consumer
+        let fakeRootURL: URL = "/xxxxxxxxxxC"
+        let appender = XcodeProjBuildSettingsIntegrateAppender(mode: mode, repoRoot: rootURL, fakeSrcRoot: fakeRootURL)
+        let result = appender.appendToBuildSettings(buildSettings: buildSettings, wrappers: binaries)
+        let ldPlusPlus: String = try XCTUnwrap(result["LDPLUSPLUS"] as? String)
+
+        XCTAssertEqual(ldPlusPlus, binaries.ldplusplus.path)
+    }
 }


### PR DESCRIPTION
The follow-up to #150, where `LDPLUSPLUS` was added, but without automatic integration support.

Fixes #180