### PR TITLE
Introduce xclipo to mock lipo

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/tuist/XcodeProj.git",
         "state": {
           "branch": null,
-          "revision": "c75c3acc25460195cfd203a04dde165395bf00e0",
-          "version": "8.7.1"
+          "revision": "fae27b48bc14ff3fd9b02902e48c4665ce5a0793",
+          "version": "8.9.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,10 @@ let package = Package(
             dependencies: ["XCRemoteCache", "xclibtoolSupport"]
         ),
         .target(
+            name: "xclipo",
+            dependencies: ["XCRemoteCache"]
+        ),
+        .target(
             name: "xcpostbuild",
             dependencies: ["XCRemoteCache"]
         ),
@@ -62,7 +66,16 @@ let package = Package(
         .target(
             // Wrapper target that builds all binaries but does nothing in runtime
             name: "Aggregator",
-            dependencies: ["xcprebuild", "xcswiftc", "xclibtool", "xcpostbuild", "xcprepare", "xcld", "xcldplusplus"]
+            dependencies: [
+                "xcprebuild",
+                "xcswiftc",
+                "xclibtool",
+                "xcpostbuild",
+                "xcprepare",
+                "xcld",
+                "xcldplusplus",
+                "xclipo",
+            ]
         ),
         .testTarget(
             name: "XCRemoteCacheTests",

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(url: "https://github.com/marmelroy/Zip.git", from: "2.1.2"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.0.1"),
-        .package(url: "https://github.com/tuist/XcodeProj.git", from: "8.7.1"),
+        .package(url: "https://github.com/tuist/XcodeProj.git", from: "8.9.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Configure Xcode targets that **should use** XCRemoteCache:
 * `CC` - `xccc_file` from your `.rcinfo` configuration (e.g. `xcremotecache/xccc`)
 * `SWIFT_EXEC` - location of `xcprepare` (e.g. `xcremotecache/xcswiftc`)
 * `LIBTOOL` - location of `xclibtool` (e.g. `xcremotecache/xclibtool`)
+* `LIPO` - location of `xclipo` (e.g. `xcremotecache/xclipo`)
 * `LD` - location of `xcld` (e.g. `xcremotecache/xcld`)
 * `LDPLUSPLUS` - location of `xcldplusplus` (e.g. `xcremotecache/xcldplusplus`)
 * `XCRC_PLATFORM_PREFERRED_ARCH` - `$(LINK_FILE_LIST_$(CURRENT_VARIANT)_$(PLATFORM_PREFERRED_ARCH):dir:standardizepath:file:default=arm64)`
@@ -267,7 +268,7 @@ $ xcremotecache/xcprepare mark --configuration Debug --platform iphonesimulator
 
 That command creates an empty file on a remote server which informs that for given sha, configuration, platform, Xcode versions etc. all artifacts are available.
 
-_Note that for the `producer` mode, the prebuild build phase and `xccc`, `xcld`, `xcldplusplus`, `xclibtool` wrappers become no-op, so it is recommended to not add them for the `producer` mode._
+_Note that for the `producer` mode, the prebuild build phase and `xccc`, `xcld`, `xcldplusplus`, `xclibtool`, `xclipo` wrappers become no-op, so it is recommended to not add them for the `producer` mode._
 
 ##### 7. Generalize `-Swift.h` (Optional only if using static library with a bridging header with public `NS_ENUM` exposed from ObjC)
 

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ DERIVED_DATA_DIR = File.join('.build').freeze
 RELEASES_ROOT_DIR = File.join('releases').freeze
 
 EXECUTABLE_NAME = 'XCRemoteCache'
-EXECUTABLE_NAMES = ['xclibtool', 'xcpostbuild', 'xcprebuild', 'xcprepare', 'xcswiftc', 'xcld', 'xcldplusplus'] 
+EXECUTABLE_NAMES = ['xclibtool', 'xcpostbuild', 'xcprebuild', 'xcprepare', 'xcswiftc', 'xcld', 'xcldplusplus', 'xclipo']
 PROJECT_NAME = 'XCRemoteCache'
 
 SWIFTLINT_ENABLED = true

--- a/Sources/XCRemoteCache/Commands/Libtool/XCCreateUniversalBinary.swift
+++ b/Sources/XCRemoteCache/Commands/Libtool/XCCreateUniversalBinary.swift
@@ -52,7 +52,6 @@ class XCCreateUniversalBinary: XCLibtoolLogic {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .deletingLastPathComponent()
-        errorLog("\(tempDir.absoluteString)")
         self.firstInputURL = firstInputURL
         self.toolName = toolName
         self.fallbackCommand = fallbackCommand

--- a/Sources/XCRemoteCache/Commands/Libtool/XCLibtool.swift
+++ b/Sources/XCRemoteCache/Commands/Libtool/XCLibtool.swift
@@ -44,7 +44,12 @@ public class XCLibtool {
                 stepDescription: "Libtool"
             )
         case .createUniversalBinary(let output, let inputs):
-            logic = try XCLibtoolCreateUniversalBinary(output: output, inputs: inputs)
+            logic = try XCCreateUniversalBinary(
+                output: output,
+                inputs: inputs,
+                toolName: "Libtool",
+                fallbackCommand: "libtool"
+            )
         }
     }
 

--- a/Sources/XCRemoteCache/Commands/Libtool/XCLipo.swift
+++ b/Sources/XCRemoteCache/Commands/Libtool/XCLipo.swift
@@ -1,0 +1,50 @@
+// Copyright (c) 2023 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+/// Wrapper for a `lipo` tool that creates a fat archive
+public class XCLipo {
+    private let logic: XCLibtoolLogic
+
+    public init(
+        output: String,
+        inputs: [String],
+        fallbackCommand: String,
+        stepDescription: String
+    ) throws {
+        errorLog("\(output)")
+        errorLog("\(inputs.joined(separator: ","))")
+        logic = try XCCreateUniversalBinary(
+            output: output,
+            inputs: inputs,
+            toolName: stepDescription,
+            fallbackCommand: fallbackCommand
+        )
+    }
+
+    /// Handles a `-create` action which is responsible to create a fat archive
+    /// If remote cache can reuse artifacts from a remote cache, it just links any of input
+    /// files to the destination (output) location because the binary in XCRC artifact already
+    /// contains a fat library.
+    /// If a remote artifact cannot be reused, a fallback to the `lipo` command is performed
+    public func run() {
+        logic.run()
+    }
+}

--- a/Sources/XCRemoteCache/Commands/Libtool/XCLipo.swift
+++ b/Sources/XCRemoteCache/Commands/Libtool/XCLipo.swift
@@ -42,7 +42,7 @@ public class XCLipo {
     /// Handles a `-create` action which is responsible to create a fat archive
     /// If remote cache can reuse artifacts from a remote cache, it just links any of input
     /// files to the destination (output) location because the binary in XCRC artifact already
-    /// contains a fat library.
+    /// contains a fat library
     /// If a remote artifact cannot be reused, a fallback to the `lipo` command is performed
     public func run() {
         logic.run()

--- a/Sources/XCRemoteCache/Commands/Prepare/Integrate/BuildSettingsIntegrateAppender.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/Integrate/BuildSettingsIntegrateAppender.swift
@@ -50,6 +50,7 @@ class XcodeProjBuildSettingsIntegrateAppender: BuildSettingsIntegrateAppender {
             result["CC"] = wrappers.cc.path
             result["LD"] = wrappers.ld.path
             result["LIBTOOL"] = wrappers.libtool.path
+            result["LIPO"] = wrappers.lipo.path
             result["LDPLUSPLUS"] = wrappers.ldplusplus.path
         }
 

--- a/Sources/XCRemoteCache/Commands/Prepare/Integrate/IntegrateContext.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/Integrate/IntegrateContext.swift
@@ -52,6 +52,7 @@ extension IntegrateContext {
             cc: binariesDir.appendingPathComponent("xccc"),
             swiftc: binariesDir.appendingPathComponent("xcswiftc"),
             libtool: binariesDir.appendingPathComponent("xclibtool"),
+            lipo: binariesDir.appendingPathComponent("xclipo"),
             ld: binariesDir.appendingPathComponent("xcld"),
             ldplusplus: binariesDir.appendingPathComponent("xcldplusplus"),
             prebuild: binariesDir.appendingPathComponent("xcprebuild"),

--- a/Sources/xclipo/XCLipoMain.swift
+++ b/Sources/xclipo/XCLipoMain.swift
@@ -1,0 +1,71 @@
+// Copyright (c) 2023 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+import XCRemoteCache
+
+/// Wrapper for a `lipo` program that links any of input binaries to the destination paths
+/// Fallbacks to a standard `lipo` when the Ramote cache is not applicable (e.g. modified sources)
+public class XCLipoMain {
+    public init() { }
+
+    public func main() {
+        let args = ProcessInfo().arguments
+        var output: String?
+        var create = false
+        var inputs: [String] = []
+
+        var i = 1
+        while i < args.count {
+            switch args[i] {
+            case "-output":
+                output = args[i + 1]
+                i += 1
+            case "-create":
+                create = true
+            default:
+                inputs.append(args[i])
+            }
+            i += 1
+        }
+        let lipoCommand = "lipo"
+        guard let output = output, !inputs.isEmpty, create else {
+            print("Fallbacking to compilation using \(lipoCommand).")
+
+            let args = ProcessInfo().arguments
+            let paramList = [lipoCommand] + args.dropFirst()
+            let cargs = paramList.map { strdup($0) } + [nil]
+            execvp(lipoCommand, cargs)
+
+            /// C-function `execv` returns only when the command fails
+            exit(1)
+        }
+
+        do {
+            try XCLipo(
+                output: output,
+                inputs: inputs,
+                fallbackCommand: lipoCommand,
+                stepDescription: "xclipo"
+            ).run()
+        } catch {
+            exit(1, "Failed with: \(error). Args: \(args)")
+        }
+    }
+}

--- a/Sources/xclipo/main.swift
+++ b/Sources/xclipo/main.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Spotify AB.
+// Copyright (c) 2023 Spotify AB.
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
@@ -17,17 +17,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import Foundation
+import XCRemoteCache
 
-/// Representing locations of all XCRemoteCache binaries (including wrappers and phase scripts)
-struct XCRCBinariesPaths {
-    let prepare: URL
-    let cc: URL
-    let swiftc: URL
-    let libtool: URL
-    let lipo: URL
-    let ld: URL
-    let ldplusplus: URL
-    let prebuild: URL
-    let postbuild: URL
-}
+XCLipoMain().main()

--- a/Tests/XCRemoteCacheTests/Commands/Prepare/Integrate/XcodeProjBuildSettingsIntegrateAppenderTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/Prepare/Integrate/XcodeProjBuildSettingsIntegrateAppenderTests.swift
@@ -34,6 +34,7 @@ class XcodeProjBuildSettingsIntegrateAppenderTests: XCTestCase {
             cc: binariesDir.appendingPathComponent("xccc"),
             swiftc: binariesDir.appendingPathComponent("xcswiftc"),
             libtool: binariesDir.appendingPathComponent("xclibtool"),
+            lipo: binariesDir.appendingPathComponent("lipo"),
             ld: binariesDir.appendingPathComponent("xcld"),
             ldplusplus: binariesDir.appendingPathComponent("xcldplusplus"),
             prebuild: binariesDir.appendingPathComponent("xcprebuild"),

--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module CocoapodsXcremotecache
-  VERSION = "0.0.14"
+  VERSION = "0.0.15"
 end

--- a/e2eTests/StandaloneSampleApp/StandaloneApp.xcodeproj/project.pbxproj
+++ b/e2eTests/StandaloneSampleApp/StandaloneApp.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		36201A2A2843B3D3002FF70F /* MixedTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36201A292843B3D3002FF70F /* MixedTarget.swift */; };
 		36201A362843B435002FF70F /* libMixedTarget.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 36201A272843B3D3002FF70F /* libMixedTarget.a */; };
 		36201A392843BDDC002FF70F /* StandaloneObjc.m in Sources */ = {isa = PBXBuildFile; fileRef = 36201A382843BDDC002FF70F /* StandaloneObjc.m */; };
+		4E10D63029BBFD8000A8655C /* WatchExtensionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E10D62F29BBFD8000A8655C /* WatchExtensionExtension.swift */; };
+		4E10D63229BBFD8000A8655C /* WatchExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E10D63129BBFD8000A8655C /* WatchExtension.swift */; };
 		4EE6CF4929B6C1A000AEE1B4 /* StaticFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 4EE6CF4829B6C1A000AEE1B4 /* StaticFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4EE6CF5329B6C1AF00AEE1B4 /* StaticFrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE6CF5229B6C1AF00AEE1B4 /* StaticFrameworkFile.swift */; };
 /* End PBXBuildFile section */
@@ -27,6 +29,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 36201A262843B3D3002FF70F;
 			remoteInfo = MixedTarget;
+		};
+		4E10D63729BBFD8E00A8655C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36201A042843B3C3002FF70F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4EE6CF4529B6C1A000AEE1B4;
+			remoteInfo = StaticFramework;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -67,9 +76,10 @@
 		36201A302843B414002FF70F /* SomeObjC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SomeObjC.h; sourceTree = "<group>"; };
 		36201A372843BDDC002FF70F /* StandaloneObjc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StandaloneObjc.h; sourceTree = "<group>"; };
 		36201A382843BDDC002FF70F /* StandaloneObjc.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StandaloneObjc.m; sourceTree = "<group>"; };
-		4E628CA229B8066500AF2DB0 /* SandaloneWatchAppExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandaloneWatchAppExtension.swift; sourceTree = "<group>"; };
-		4E628CA429B8066500AF2DB0 /* SandaloneWatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandaloneWatchApp.swift; sourceTree = "<group>"; };
-		4E628CA629B8066500AF2DB0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4E10D62D29BBFD8000A8655C /* WatchExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = WatchExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		4E10D62F29BBFD8000A8655C /* WatchExtensionExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchExtensionExtension.swift; sourceTree = "<group>"; };
+		4E10D63129BBFD8000A8655C /* WatchExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchExtension.swift; sourceTree = "<group>"; };
+		4E10D63329BBFD8000A8655C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4EE6CF4629B6C1A000AEE1B4 /* StaticFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StaticFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4EE6CF4829B6C1A000AEE1B4 /* StaticFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StaticFramework.h; sourceTree = "<group>"; };
 		4EE6CF5229B6C1AF00AEE1B4 /* StaticFrameworkFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StaticFrameworkFile.swift; sourceTree = "<group>"; };
@@ -85,6 +95,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		36201A242843B3D3002FF70F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4E10D62A29BBFD8000A8655C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -107,7 +124,7 @@
 				36201A0E2843B3C3002FF70F /* StandaloneApp */,
 				36201A282843B3D3002FF70F /* MixedTarget */,
 				4EE6CF4729B6C1A000AEE1B4 /* StaticFramework */,
-				4E628CA129B8066500AF2DB0 /* SandaloneWatchApp */,
+				4E10D62E29BBFD8000A8655C /* WatchExtension */,
 				36201A0D2843B3C3002FF70F /* Products */,
 				36201A352843B435002FF70F /* Frameworks */,
 			);
@@ -119,6 +136,7 @@
 				36201A0C2843B3C3002FF70F /* StandaloneApp.app */,
 				36201A272843B3D3002FF70F /* libMixedTarget.a */,
 				4EE6CF4629B6C1A000AEE1B4 /* StaticFramework.framework */,
+				4E10D62D29BBFD8000A8655C /* WatchExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -156,14 +174,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		4E628CA129B8066500AF2DB0 /* SandaloneWatchApp */ = {
+		4E10D62E29BBFD8000A8655C /* WatchExtension */ = {
 			isa = PBXGroup;
 			children = (
-				4E628CA229B8066500AF2DB0 /* SandaloneWatchAppExtension.swift */,
-				4E628CA429B8066500AF2DB0 /* SandaloneWatchApp.swift */,
-				4E628CA629B8066500AF2DB0 /* Info.plist */,
+				4E10D62F29BBFD8000A8655C /* WatchExtensionExtension.swift */,
+				4E10D63129BBFD8000A8655C /* WatchExtension.swift */,
+				4E10D63329BBFD8000A8655C /* Info.plist */,
 			);
-			path = SandaloneWatchApp;
+			path = WatchExtension;
 			sourceTree = "<group>";
 		};
 		4EE6CF4729B6C1A000AEE1B4 /* StaticFramework */ = {
@@ -226,6 +244,24 @@
 			productReference = 36201A272843B3D3002FF70F /* libMixedTarget.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		4E10D62C29BBFD8000A8655C /* WatchExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4E10D63429BBFD8000A8655C /* Build configuration list for PBXNativeTarget "WatchExtension" */;
+			buildPhases = (
+				4E10D62929BBFD8000A8655C /* Sources */,
+				4E10D62A29BBFD8000A8655C /* Frameworks */,
+				4E10D62B29BBFD8000A8655C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4E10D63829BBFD8E00A8655C /* PBXTargetDependency */,
+			);
+			name = WatchExtension;
+			productName = WatchExtension;
+			productReference = 4E10D62D29BBFD8000A8655C /* WatchExtension.appex */;
+			productType = "com.apple.product-type.extensionkit-extension";
+		};
 		4EE6CF4529B6C1A000AEE1B4 /* StaticFramework */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4EE6CF5129B6C1A000AEE1B4 /* Build configuration list for PBXNativeTarget "StaticFramework" */;
@@ -262,6 +298,9 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
 					};
+					4E10D62C29BBFD8000A8655C = {
+						CreatedOnToolsVersion = 14.2;
+					};
 					4EE6CF4529B6C1A000AEE1B4 = {
 						CreatedOnToolsVersion = 14.2;
 						LastSwiftMigration = 1420;
@@ -284,6 +323,7 @@
 				36201A0B2843B3C3002FF70F /* StandaloneApp */,
 				36201A262843B3D3002FF70F /* MixedTarget */,
 				4EE6CF4529B6C1A000AEE1B4 /* StaticFramework */,
+				4E10D62C29BBFD8000A8655C /* WatchExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -296,6 +336,13 @@
 				36201A1C2843B3C7002FF70F /* LaunchScreen.storyboard in Resources */,
 				36201A192843B3C7002FF70F /* Assets.xcassets in Resources */,
 				36201A172843B3C3002FF70F /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4E10D62B29BBFD8000A8655C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -353,6 +400,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4E10D62929BBFD8000A8655C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4E10D63029BBFD8000A8655C /* WatchExtensionExtension.swift in Sources */,
+				4E10D63229BBFD8000A8655C /* WatchExtension.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4EE6CF4229B6C1A000AEE1B4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -368,6 +424,11 @@
 			isa = PBXTargetDependency;
 			target = 36201A262843B3D3002FF70F /* MixedTarget */;
 			targetProxy = 36201A332843B431002FF70F /* PBXContainerItemProxy */;
+		};
+		4E10D63829BBFD8E00A8655C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4EE6CF4529B6C1A000AEE1B4 /* StaticFramework */;
+			targetProxy = 4E10D63729BBFD8E00A8655C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -607,6 +668,62 @@
 			};
 			name = Release;
 		};
+		4E10D63529BBFD8000A8655C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = WatchExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = WatchExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.xcremotecache.WatchExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = Debug;
+		};
+		4E10D63629BBFD8000A8655C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = WatchExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = WatchExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.xcremotecache.WatchExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = Release;
+		};
 		4EE6CF4F29B6C1A000AEE1B4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -706,6 +823,15 @@
 			buildConfigurations = (
 				36201A2C2843B3D3002FF70F /* Debug */,
 				36201A2D2843B3D3002FF70F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4E10D63429BBFD8000A8655C /* Build configuration list for PBXNativeTarget "WatchExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4E10D63529BBFD8000A8655C /* Debug */,
+				4E10D63629BBFD8000A8655C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/e2eTests/StandaloneSampleApp/StandaloneApp.xcodeproj/xcshareddata/xcschemes/SampleWatchApp.xcscheme
+++ b/e2eTests/StandaloneSampleApp/StandaloneApp.xcodeproj/xcshareddata/xcschemes/SampleWatchApp.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4E10D61129BBF2FA00A8655C"
+               BuildableName = "SampleWatchApp.app"
+               BlueprintName = "SampleWatchApp"
+               ReferencedContainer = "container:StandaloneApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4E10D61129BBF2FA00A8655C"
+               BuildableName = "SampleWatchApp.app"
+               BlueprintName = "SampleWatchApp"
+               ReferencedContainer = "container:StandaloneApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4E10D61129BBF2FA00A8655C"
+            BuildableName = "SampleWatchApp.app"
+            BlueprintName = "SampleWatchApp"
+            ReferencedContainer = "container:StandaloneApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4E10D61129BBF2FA00A8655C"
+            BuildableName = "SampleWatchApp.app"
+            BlueprintName = "SampleWatchApp"
+            ReferencedContainer = "container:StandaloneApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/e2eTests/StandaloneSampleApp/WatchExtension/Info.plist
+++ b/e2eTests/StandaloneSampleApp/WatchExtension/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EXAppExtensionAttributes</key>
+	<dict>
+		<key>EXExtensionPointIdentifier</key>
+		<string>com.apple.appintents-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/e2eTests/StandaloneSampleApp/WatchExtension/WatchExtension.swift
+++ b/e2eTests/StandaloneSampleApp/WatchExtension/WatchExtension.swift
@@ -1,0 +1,2 @@
+import AppIntents
+

--- a/e2eTests/StandaloneSampleApp/WatchExtension/WatchExtensionExtension.swift
+++ b/e2eTests/StandaloneSampleApp/WatchExtension/WatchExtensionExtension.swift
@@ -1,0 +1,4 @@
+import AppIntents
+
+struct WatchExtensionExtension: AppIntentsExtension {
+}

--- a/tasks/e2e.rb
+++ b/tasks/e2e.rb
@@ -58,7 +58,7 @@ namespace :e2e do
             system("pwd")
             system("#{XCRC_BINARIES}/xcprepare integrate --input StandaloneApp.xcodeproj --mode producer --final-producer-target StandaloneApp")
             # Build the project to fill in the cache
-            build_project(nil, "StandaloneApp.xcodeproj", 'StaticFramework', 'watch', 'watchOS')
+            build_project(nil, "StandaloneApp.xcodeproj", 'WatchExtension', 'watch', 'watchOS')
             build_project(nil, "StandaloneApp.xcodeproj", 'StandaloneApp')
             system("#{XCRC_BINARIES}/xcprepare stats --reset --format json")
         end
@@ -74,14 +74,14 @@ namespace :e2e do
         prepare_for_standalone(consumer_srcroot)
         Dir.chdir(consumer_srcroot) do
             system("#{XCRC_BINARIES}/xcprepare integrate --input StandaloneApp.xcodeproj --mode consumer")
-            build_project(nil, "StandaloneApp.xcodeproj", 'StaticFramework', 'watch', 'watchOS', {'derivedDataPath' => "#{DERIVED_DATA_PATH}_consumer"})
+            build_project(nil, "StandaloneApp.xcodeproj", 'WatchExtension', 'watch', 'watchOS', {'derivedDataPath' => "#{DERIVED_DATA_PATH}_consumer"})
             build_project(nil, "StandaloneApp.xcodeproj", 'StandaloneApp', 'iphone', 'iOS', {'derivedDataPath' => "#{DERIVED_DATA_PATH}_consumer"})
             valide_hit_rate
 
             puts 'Building standalone consumer with local change...'
             # Extra: validate local compilation of the Standalone ObjC code
             system("echo '' >> StandaloneApp/StandaloneObjc.m")
-            build_project(nil, "StandaloneApp.xcodeproj", 'StaticFramework', 'watch', 'watchOS', {'derivedDataPath' => "#{DERIVED_DATA_PATH}_consumer_local"})
+            build_project(nil, "StandaloneApp.xcodeproj", 'WatchExtension', 'watch', 'watchOS', {'derivedDataPath' => "#{DERIVED_DATA_PATH}_consumer_local"})
             build_project(nil, "StandaloneApp.xcodeproj", 'StandaloneApp', 'iphone', 'iOS', {'derivedDataPath' => "#{DERIVED_DATA_PATH}_consumer_local"})
         end
 


### PR DESCRIPTION
Follow-up to #185:

* Mocks `lipo` with `xclipo` that creates a dynamic fat library. The logic is the same as in the `xclibtool` that just takes any of input files and creates a hard link.
* Add E2E test that covers `xclipo` scenario. The PR that proves that it covers that - #189 includes only that E2E tests 
* ^ E2E test adds a watch extension `WatchExtension`, which depends on `StaticFramework` added in #185. To cover both universal binary scenario (static and dynamic), building `WatchExtension` is enough
* Bumps Xcodeproj to support watch extensions (https://github.com/tuist/XcodeProj/issues/687)

This PR adds support for dynamic fat archives, reported in #187 

Fixes #187