### PR TITLE
Encode path in AWS V4 signing requests

### DIFF
--- a/Sources/XCRemoteCache/Network/Authentication/CanonicalRequest.swift
+++ b/Sources/XCRemoteCache/Network/Authentication/CanonicalRequest.swift
@@ -34,7 +34,15 @@ struct CanonicalRequest {
         if url.path.isEmpty {
             path = "/"
         } else {
-            path = url.path
+            if let escapedPath = url.path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) {
+                path = escapedPath
+            } else {
+                path = "/"
+                printWarning("""
+Escaping the path \(url.path) failed and a placeholder is used instead. \
+Make sure the path doesn't contain invalid characters.
+""")
+            }
         }
         return
             "\(httpMethod)\n" +

--- a/Tests/XCRemoteCacheTests/Network/Authentication/CanonicalRequestTest.swift
+++ b/Tests/XCRemoteCacheTests/Network/Authentication/CanonicalRequestTest.swift
@@ -37,6 +37,27 @@ class CanonicalRequestTest: XCTestCase {
     }
 
     func testCanonicalRequest() {
+        request.url = URL(
+            string: "https://region.amazonaws.com/bucket/with%20space?param=value&hej=hej&abd=cde&test=-_.~"
+        )!
+        let canonicalRequest = CanonicalRequest(
+            request: request
+        )
+        XCTAssertEqual(
+            canonicalRequest.value,
+            "GET\n" +
+                "/bucket/with%20space\n" +
+                "abd=cde&hej=hej&param=value&test=-_.~\n" +
+                "a-header2key:A-Header2Value\n" +
+                "b-header3key:B-Header3Value\n" +
+                "c-header4key:C Header 4 Value\n" +
+                "x-header1key:X-Header1Value\n\n" +
+                "a-header2key;b-header3key;c-header4key;x-header1key\n" +
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        )
+    }
+
+    func testCanonicalRequestWithEmptySpaceInPath() {
         let canonicalRequest = CanonicalRequest(
             request: request
         )


### PR DESCRIPTION
As the [doc](https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html) says, the path should be URL encoded
```
CanonicalUri – The URI-encoded version of the absolute path component URL (everything between the host and the question mark character (?) that starts the query string parameters). If the absolute path is empty, use a forward slash character (/).
```

This PR ensures we escape that - it might happen if a target or Configuration has e.g. whitespace.

Fixes #192