### PR TITLE
Set libtool Build Setting for excluded sdks

### DIFF
--- a/Sources/XCRemoteCache/Commands/Prepare/Integrate/BuildSettingsIntegrateAppender.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/Integrate/BuildSettingsIntegrateAppender.swift
@@ -51,7 +51,9 @@ class XcodeProjBuildSettingsIntegrateAppender: BuildSettingsIntegrateAppender {
         if case .consumer = mode {
             setBuildSetting(buildSettings: &result, key: "CC", value: wrappers.cc.path )
             setBuildSetting(buildSettings: &result, key: "LD", value: wrappers.ld.path )
-            setBuildSetting(buildSettings: &result, key: "LIBTOOL", value: wrappers.libtool.path )
+            // Setting LIBTOOL to '' breaks SwiftDriver intengration so resetting it to the original value
+            // 'libtool' for all excluded configurations
+            setBuildSetting(buildSettings: &result, key: "LIBTOOL", value: wrappers.libtool.path, excludedValue: "libtool")
             setBuildSetting(buildSettings: &result, key: "LIPO", value: wrappers.lipo.path )
             setBuildSetting(buildSettings: &result, key: "LDPLUSPLUS", value: wrappers.ldplusplus.path )
         }
@@ -79,7 +81,7 @@ class XcodeProjBuildSettingsIntegrateAppender: BuildSettingsIntegrateAppender {
         return result
     }
 
-    private func setBuildSetting(buildSettings: inout BuildSettings, key: String, value: String?) {
+    private func setBuildSetting(buildSettings: inout BuildSettings, key: String, value: String?, excludedValue: String = "") {
         buildSettings[key] = value
         guard value != nil else {
             // no need to exclude as the value will
@@ -87,7 +89,7 @@ class XcodeProjBuildSettingsIntegrateAppender: BuildSettingsIntegrateAppender {
         }
         // Erase all overrides for a given sdk so a default toolchain is used
         for skippedSDK in sdksExclude {
-            buildSettings["\(key)[sdk=\(skippedSDK)]"] = ""
+            buildSettings["\(key)[sdk=\(skippedSDK)]"] = excludedValue
         }
     }
 

--- a/Sources/XCRemoteCache/Commands/Prepare/Integrate/BuildSettingsIntegrateAppender.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/Integrate/BuildSettingsIntegrateAppender.swift
@@ -53,7 +53,12 @@ class XcodeProjBuildSettingsIntegrateAppender: BuildSettingsIntegrateAppender {
             setBuildSetting(buildSettings: &result, key: "LD", value: wrappers.ld.path )
             // Setting LIBTOOL to '' breaks SwiftDriver intengration so resetting it to the original value
             // 'libtool' for all excluded configurations
-            setBuildSetting(buildSettings: &result, key: "LIBTOOL", value: wrappers.libtool.path, excludedValue: "libtool")
+            setBuildSetting(
+                buildSettings: &result,
+                key: "LIBTOOL",
+                value: wrappers.libtool.path,
+                excludedValue: "libtool"
+            )
             setBuildSetting(buildSettings: &result, key: "LIPO", value: wrappers.lipo.path )
             setBuildSetting(buildSettings: &result, key: "LDPLUSPLUS", value: wrappers.ldplusplus.path )
         }

--- a/Tests/XCRemoteCacheTests/Commands/Prepare/Integrate/XcodeProjBuildSettingsIntegrateAppenderTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/Prepare/Integrate/XcodeProjBuildSettingsIntegrateAppenderTests.swift
@@ -101,6 +101,20 @@ class XcodeProjBuildSettingsIntegrateAppenderTests: XCTestCase {
         XCTAssertEqual(ldPlusPlusWatchOS, "")
     }
 
+    func testLibtoolIsSetForExcludedSdks() throws {
+        let mode: Mode = .consumer
+        let appender = XcodeProjBuildSettingsIntegrateAppender(
+            mode: mode,
+            repoRoot: rootURL,
+            fakeSrcRoot: "/",
+            sdksExclude: ["watchOS*"]
+        )
+        let result = appender.appendToBuildSettings(buildSettings: buildSettings, wrappers: binaries)
+        let libtoolWatchOS: String = try XCTUnwrap(result["LIBTOOL[sdk=watchOS*]"] as? String)
+
+        XCTAssertEqual(libtoolWatchOS, "libtool")
+    }
+
     func testMultiplesdksExcludeAreAppended() throws {
         let mode: Mode = .consumer
         let appender = XcodeProjBuildSettingsIntegrateAppender(

--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
@@ -138,6 +138,8 @@ module CocoapodsXCRemoteCacheModifier
             config.build_settings.delete('CC') if config.build_settings.key?('CC')
           end
           reset_build_setting(config.build_settings, 'SWIFT_EXEC', "$SRCROOT/#{srcroot_relative_xc_location}/xcswiftc", exclude_sdks_configurations)
+          # Settings SWIFT_EXEC to '' breaks SwiftDriver intengration so resetting it to the original value 'swiftc'
+          add_build_setting_for_sdks(config.build_settings, 'SWIFT_EXEC', 'swiftc', exclude_sdks_configurations)
           reset_build_setting(config.build_settings, 'LIBTOOL', "$SRCROOT/#{srcroot_relative_xc_location}/xclibtool", exclude_sdks_configurations)
           reset_build_setting(config.build_settings, 'LD', "$SRCROOT/#{srcroot_relative_xc_location}/xcld", exclude_sdks_configurations)
           reset_build_setting(config.build_settings, 'LDPLUSPLUS', "$SRCROOT/#{srcroot_relative_xc_location}/xcldplusplus", exclude_sdks_configurations)

--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
@@ -141,6 +141,8 @@ module CocoapodsXCRemoteCacheModifier
           # Settings SWIFT_EXEC to '' breaks SwiftDriver intengration so resetting it to the original value 'swiftc'
           add_build_setting_for_sdks(config.build_settings, 'SWIFT_EXEC', 'swiftc', exclude_sdks_configurations)
           reset_build_setting(config.build_settings, 'LIBTOOL', "$SRCROOT/#{srcroot_relative_xc_location}/xclibtool", exclude_sdks_configurations)
+          # Settings LIBTOOL to '' breaks SwiftDriver intengration so resetting it to the original value 'libtool'
+          add_build_setting_for_sdks(config.build_settings, 'LIBTOOL', 'libtool', exclude_sdks_configurations)
           reset_build_setting(config.build_settings, 'LD', "$SRCROOT/#{srcroot_relative_xc_location}/xcld", exclude_sdks_configurations)
           reset_build_setting(config.build_settings, 'LDPLUSPLUS', "$SRCROOT/#{srcroot_relative_xc_location}/xcldplusplus", exclude_sdks_configurations)
           reset_build_setting(config.build_settings, 'LIPO', "$SRCROOT/#{srcroot_relative_xc_location}/xclipo", exclude_sdks_configurations)

--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
@@ -138,11 +138,9 @@ module CocoapodsXCRemoteCacheModifier
             config.build_settings.delete('CC') if config.build_settings.key?('CC')
           end
           reset_build_setting(config.build_settings, 'SWIFT_EXEC', "$SRCROOT/#{srcroot_relative_xc_location}/xcswiftc", exclude_sdks_configurations)
-          # Settings SWIFT_EXEC to '' breaks SwiftDriver intengration so resetting it to the original value 'swiftc'
-          add_build_setting_for_sdks(config.build_settings, 'SWIFT_EXEC', 'swiftc', exclude_sdks_configurations)
           reset_build_setting(config.build_settings, 'LIBTOOL', "$SRCROOT/#{srcroot_relative_xc_location}/xclibtool", exclude_sdks_configurations)
-          # Settings LIBTOOL to '' breaks SwiftDriver intengration so resetting it to the original value 'libtool'
-          add_build_setting_for_sdks(config.build_settings, 'LIBTOOL', 'libtool', exclude_sdks_configurations)
+          # Setting LIBTOOL to '' breaks SwiftDriver intengration so resetting it to the original value 'libtool' for all excluded configurations
+          add_build_setting_for_sdks(config.build_settings, 'LIBTOOL', 'libtool', exclude_sdks_configurations) unless exclude_sdks_configurations.empty?
           reset_build_setting(config.build_settings, 'LD', "$SRCROOT/#{srcroot_relative_xc_location}/xcld", exclude_sdks_configurations)
           reset_build_setting(config.build_settings, 'LDPLUSPLUS', "$SRCROOT/#{srcroot_relative_xc_location}/xcldplusplus", exclude_sdks_configurations)
           reset_build_setting(config.build_settings, 'LIPO', "$SRCROOT/#{srcroot_relative_xc_location}/xclipo", exclude_sdks_configurations)

--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/command/hooks.rb
@@ -140,7 +140,7 @@ module CocoapodsXCRemoteCacheModifier
           reset_build_setting(config.build_settings, 'SWIFT_EXEC', "$SRCROOT/#{srcroot_relative_xc_location}/xcswiftc", exclude_sdks_configurations)
           reset_build_setting(config.build_settings, 'LIBTOOL', "$SRCROOT/#{srcroot_relative_xc_location}/xclibtool", exclude_sdks_configurations)
           # Setting LIBTOOL to '' breaks SwiftDriver intengration so resetting it to the original value 'libtool' for all excluded configurations
-          add_build_setting_for_sdks(config.build_settings, 'LIBTOOL', 'libtool', exclude_sdks_configurations) unless exclude_sdks_configurations.empty?
+          add_build_setting_for_sdks(config.build_settings, 'LIBTOOL', 'libtool', exclude_sdks_configurations)
           reset_build_setting(config.build_settings, 'LD', "$SRCROOT/#{srcroot_relative_xc_location}/xcld", exclude_sdks_configurations)
           reset_build_setting(config.build_settings, 'LDPLUSPLUS', "$SRCROOT/#{srcroot_relative_xc_location}/xcldplusplus", exclude_sdks_configurations)
           reset_build_setting(config.build_settings, 'LIPO', "$SRCROOT/#{srcroot_relative_xc_location}/xclipo", exclude_sdks_configurations)


### PR DESCRIPTION
As reported in #190, if LIBTOOL Build setting is set to `""`, static library cannot build ObjC files and fails with a cryptic error:
```
unable to spawn process '/Applications/Xcode.app/Contents/SharedFrameworks/XCBuild.framework/Versions/A/PlugIns/XCBBuildService.bundle/Contents/Frameworks/../../../../../../../../PlugIns/XCBSpecifications.ideplugin/Contents/Resources' (Permission denied)
```

This PR sets it to the original `libtool` value so for excluded wachOS, it looks like:
 
<img width="579" alt="image" src="https://user-images.githubusercontent.com/9629417/231917975-0af49f2d-f086-46dd-a5df-46570f6232fd.png">

This workaround is added to the cocoapods and standalone integrations.
