### PR TITLE
Add support for graceful handling missing common sha

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Note: This step is not required if at least one of these is true:
 | `disable_vfs_overlay` | A feature flag to disable virtual file system overlay support (temporary) | `false` | ⬜️ |
 | `custom_rewrite_envs` | A list of extra ENVs that should be used as placeholders in the dependency list. ENV rewrite process is optimistic - does nothing if an ENV is not defined in the pre/postbuild process. | `[]` | ⬜️ |
 | `irrelevant_dependencies_paths` | Regexes of files that should not be included in a list of dependencies. Warning! Add entries here with caution - excluding dependencies that are relevant might lead to a target overcaching. The regex can match either partially or fully the filepath, e.g. `\\.modulemap$` will exclude all `.modulemap` files. | `[]` | ⬜️ |
-| `gracefully_handle_missing_common_sha` | It true, do not fail `prepare` if cannot find the most recent commont commits with the primary branch. That might useful on CI, where a shallow clone is used and cloning depth is not big enough to fetch include a commit from a primary branch | `false` | ⬜️ |
+| `gracefully_handle_missing_common_sha` | If true, do not fail `prepare` if cannot find the most recent common commits with the primary branch. That might be useful on CI, where a shallow clone is used and cloning depth is not big enough to fetch a commit from a primary branch | `false` | ⬜️ |
 
 ## Backend cache server
 

--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ Note: This step is not required if at least one of these is true:
 | `disable_vfs_overlay` | A feature flag to disable virtual file system overlay support (temporary) | `false` | ⬜️ |
 | `custom_rewrite_envs` | A list of extra ENVs that should be used as placeholders in the dependency list. ENV rewrite process is optimistic - does nothing if an ENV is not defined in the pre/postbuild process. | `[]` | ⬜️ |
 | `irrelevant_dependencies_paths` | Regexes of files that should not be included in a list of dependencies. Warning! Add entries here with caution - excluding dependencies that are relevant might lead to a target overcaching. The regex can match either partially or fully the filepath, e.g. `\\.modulemap$` will exclude all `.modulemap` files. | `[]` | ⬜️ |
+| `gracefully_handle_missing_common_sha` | It true, do not fail `prepare` if cannot find the most recent commont commits with the primary branch. That might useful on CI, where a shallow clone is used and cloning depth is not big enough to fetch include a commit from a primary branch | `false` | ⬜️ |
 
 ## Backend cache server
 

--- a/Sources/XCRemoteCache/Commands/Prepare/PrepareContext.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/PrepareContext.swift
@@ -52,6 +52,8 @@ public struct PrepareContext {
     let cacheHealthPathProbeCount: Int
     /// clang wrapper output file
     let xcccCommand: URL
+    /// gracefully disable remote cache for missing common sha with the primary branch
+    let gracefullyHandleMissingCommonSha: Bool
 }
 
 extension PrepareContext {
@@ -77,5 +79,6 @@ extension PrepareContext {
         cacheAddresses = try config.cacheAddresses.map(URL.build)
         cacheHealthPath = config.cacheHealthPath
         cacheHealthPathProbeCount = config.cacheHealthPathProbeCount
+        gracefullyHandleMissingCommonSha = config.gracefullyHandleMissingCommonSha
     }
 }

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -148,6 +148,9 @@ public struct XCRemoteCacheConfig: Encodable {
     /// Note: The regex can match either partially or fully the filepath, e.g. `\\.modulemap$` will exclude
     /// all `.modulemap` files
     var irrelevantDependenciesPaths: [String] = []
+    /// It true, do not fail `prepare` if cannot find the most recent commont commits with the primary branch
+    /// That might useful on CI, where a shallow clone is used
+    var gracefullyHandleMissingCommonSha: Bool = false
 }
 
 extension XCRemoteCacheConfig {
@@ -206,6 +209,7 @@ extension XCRemoteCacheConfig {
         merge.disableVFSOverlay = scheme.disableVFSOverlay ?? disableVFSOverlay
         merge.customRewriteEnvs = scheme.customRewriteEnvs ?? customRewriteEnvs
         merge.irrelevantDependenciesPaths = scheme.irrelevantDependenciesPaths ?? irrelevantDependenciesPaths
+        merge.gracefullyHandleMissingCommonSha = scheme.gracefullyHandleMissingCommonSha ?? gracefullyHandleMissingCommonSha
         return merge
     }
 
@@ -273,6 +277,7 @@ struct ConfigFileScheme: Decodable {
     let disableVFSOverlay: Bool?
     let customRewriteEnvs: [String]?
     let irrelevantDependenciesPaths: [String]?
+    let gracefullyHandleMissingCommonSha: Bool?
 
     // Yams library doesn't support encoding strategy, see https://github.com/jpsim/Yams/issues/84
     enum CodingKeys: String, CodingKey {
@@ -323,6 +328,7 @@ struct ConfigFileScheme: Decodable {
         case disableVFSOverlay = "disable_vfs_overlay"
         case customRewriteEnvs = "custom_rewrite_envs"
         case irrelevantDependenciesPaths = "irrelevant_dependencies_paths"
+        case gracefullyHandleMissingCommonSha = "gracefully_handle_missing_common_sha"
     }
 }
 

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -209,7 +209,8 @@ extension XCRemoteCacheConfig {
         merge.disableVFSOverlay = scheme.disableVFSOverlay ?? disableVFSOverlay
         merge.customRewriteEnvs = scheme.customRewriteEnvs ?? customRewriteEnvs
         merge.irrelevantDependenciesPaths = scheme.irrelevantDependenciesPaths ?? irrelevantDependenciesPaths
-        merge.gracefullyHandleMissingCommonSha = scheme.gracefullyHandleMissingCommonSha ?? gracefullyHandleMissingCommonSha
+        merge.gracefullyHandleMissingCommonSha =
+            scheme.gracefullyHandleMissingCommonSha ?? gracefullyHandleMissingCommonSha
         return merge
     }
 

--- a/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
+++ b/Sources/XCRemoteCache/Config/XCRemoteCacheConfig.swift
@@ -148,7 +148,7 @@ public struct XCRemoteCacheConfig: Encodable {
     /// Note: The regex can match either partially or fully the filepath, e.g. `\\.modulemap$` will exclude
     /// all `.modulemap` files
     var irrelevantDependenciesPaths: [String] = []
-    /// It true, do not fail `prepare` if cannot find the most recent commont commits with the primary branch
+    /// If true, do not fail `prepare` if cannot find the most recent common commits with the primary branch
     /// That might useful on CI, where a shallow clone is used
     var gracefullyHandleMissingCommonSha: Bool = false
 }

--- a/Tests/XCRemoteCacheTests/TestDoubles/GitClientFake.swift
+++ b/Tests/XCRemoteCacheTests/TestDoubles/GitClientFake.swift
@@ -34,7 +34,10 @@ class GitClientFake: GitClient {
     }
 
     func getCommonPrimarySha() throws -> String {
-        shaHistory[primaryBranchIndex].sha
+        guard shaHistory.count > primaryBranchIndex else {
+            throw GitClientError.noCommonShaWithPrimaryRepo(remoteName: "testing", error: "SampleError")
+        }
+        return shaHistory[primaryBranchIndex].sha
     }
 
     func getShaDate(sha: String) throws -> Date {


### PR DESCRIPTION
Add a parameter `gracefully_handle_missing_common_sha` (disabled by default) to not fail the preparation step if git cannot find a common sha with the primary branch. 

Requested in #190