### PR TITLE
Support Xcode14.3

### DIFF
--- a/Sources/XCRemoteCache/Commands/Libtool/FallbackXCLibtoolLogic.swift
+++ b/Sources/XCRemoteCache/Commands/Libtool/FallbackXCLibtoolLogic.swift
@@ -1,0 +1,37 @@
+// Copyright (c) 2023 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+class FallbackXCLibtoolLogic: XCLibtoolLogic {
+    private let fallbackCommand: String
+
+    init(fallbackCommand: String) {
+        self.fallbackCommand = fallbackCommand
+    }
+
+    func run() {
+        let args = ProcessInfo().arguments
+        let paramList = [fallbackCommand] + args.dropFirst()
+        let cargs = paramList.map { strdup($0) } + [nil]
+        execvp(fallbackCommand, cargs)
+
+        exit(1)
+    }
+}

--- a/Sources/XCRemoteCache/Commands/Libtool/XCLibtool.swift
+++ b/Sources/XCRemoteCache/Commands/Libtool/XCLibtool.swift
@@ -25,6 +25,8 @@ public enum XCLibtoolMode: Equatable {
     case createLibrary(output: String, filelist: String, dependencyInfo: String)
     /// Creating a universal library (multiple-architectures) from a set of input .a static libraries
     case createUniversalBinary(output: String, inputs: [String])
+    /// print the toolchain version
+    case version
 }
 
 public class XCLibtool {
@@ -50,6 +52,8 @@ public class XCLibtool {
                 toolName: "Libtool",
                 fallbackCommand: "libtool"
             )
+        case .version:
+            logic = FallbackXCLibtoolLogic(fallbackCommand: "libtool")
         }
     }
 

--- a/Sources/XCRemoteCache/Dependencies/CacheModeController.swift
+++ b/Sources/XCRemoteCache/Dependencies/CacheModeController.swift
@@ -110,7 +110,7 @@ class PhaseCacheModeController: CacheModeController {
         } catch {
             // Gracefully don't disable a cache
             // That may happen if building a target for the first time
-            errorLog("Couldn't verify if should disable RC for \(commitValue).")
+            debugLog("Couldn't verify if should disable RC for \(commitValue).")
         }
         return false
     }

--- a/Sources/xclibtoolSupport/XCLibtoolHelper.swift
+++ b/Sources/xclibtoolSupport/XCLibtoolHelper.swift
@@ -32,9 +32,12 @@ public class XCLibtoolHelper {
         var inputLibraries: [String] = []
         var filelist: String?
         var dependencyInfo: String?
+        var asksForVersion = false
         var i = 0
         while i < args.count {
             switch args[i] {
+            case "-V":
+                asksForVersion = true
             case "-o":
                 output = args[i + 1]
                 i += 1
@@ -51,6 +54,9 @@ public class XCLibtoolHelper {
                 break
             }
             i += 1
+        }
+        if asksForVersion {
+            return .version
         }
         guard let outputInput = output else {
             throw XCLibtoolHelperError.missingOutput


### PR DESCRIPTION
* Adds support for Xcode 14.3, which invokes `libtool -V`

Besides:
* Standarize the configuration in E2E to Debug (no logic change - just to make it simpler switching to Release)
* Change the error -> debug about one misleading log

Reporeted in #195