### PR TITLE
Refactor existing implementation for swift-driver change

### DIFF
--- a/Sources/XCRemoteCache/Commands/Prepare/Integrate/XCIntegrate.swift
+++ b/Sources/XCRemoteCache/Commands/Prepare/Integrate/XCIntegrate.swift
@@ -98,11 +98,15 @@ public class XCIntegrate {
                 excludes: targetsExclude.integrateArrayArguments,
                 includes: targetsInclude.integrateArrayArguments
             )
+            let buildSettingsAppenderOptions: BuildSettingsIntegrateAppenderOption = [
+                .disableSwiftDriverIntegration
+            ]
             let buildSettingsAppender = XcodeProjBuildSettingsIntegrateAppender(
                 mode: context.mode,
                 repoRoot: context.repoRoot,
                 fakeSrcRoot: context.fakeSrcRoot,
-                sdksExclude: sdksExclude.integrateArrayArguments
+                sdksExclude: sdksExclude.integrateArrayArguments,
+                options: buildSettingsAppenderOptions
             )
             let lldbPatcher: LLDBInitPatcher
             switch lldbMode {

--- a/Sources/XCRemoteCache/Commands/Swiftc/NoopSwiftcProductsGenerator.swift
+++ b/Sources/XCRemoteCache/Commands/Swiftc/NoopSwiftcProductsGenerator.swift
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+/// Products generator that doesn't create any swiftmodule. It is used in the compilation swift-frontend mocking, where
+/// only individual .o files are created and not .swiftmodule of -Swift.h
+/// (which is part of swift-frontend -emit-module invocation)
+class NoopSwiftcProductsGenerator: SwiftcProductsGenerator {
+    func generateFrom(
+        artifactSwiftModuleFiles: [SwiftmoduleFileExtension: URL],
+        artifactSwiftModuleObjCFile: URL
+    ) throws -> SwiftcProductsGeneratorOutput {
+        infoLog("""
+        Invoking module generation from NoopSwiftcProductsGenerator does nothing. \
+        It might be a side-effect of a plugin asking to generate a module.
+        """)
+        // NoopSwiftcProductsGenerator is intended only for the swift-frontend
+        let trivialURL = URL(fileURLWithPath: "/non-existing")
+        return SwiftcProductsGeneratorOutput(swiftmoduleDir: trivialURL, objcHeaderFile: trivialURL)
+    }
+}

--- a/Sources/XCRemoteCache/Commands/Swiftc/SwiftcContext.swift
+++ b/Sources/XCRemoteCache/Commands/Swiftc/SwiftcContext.swift
@@ -20,6 +20,53 @@
 import Foundation
 
 public struct SwiftcContext {
+    /// Describes the action if the module emit should happen
+    /// that generates .swiftmodule and/or -Swift.h
+    public struct SwiftcStepEmitModule {
+        // where the -Swift.h should be placed
+        let objcHeaderOutput: URL
+        // where should the .swiftmodule be placed
+        let modulePathOutput: URL
+        // might be passed as an explicit argument in the swiftc
+        // -emit-dependencies-path
+        let dependencies: URL?
+    }
+
+    /// Which files (from the list of all files in the module)
+    /// should be compiled in this process
+    public enum SwiftcStepCompileFilesScope {
+        /// used if only emit module should be done
+        case none
+        case all
+        case subset([URL])
+    }
+
+    /// Describes which steps should be done as a part of this process
+    public struct SwiftcSteps {
+        /// which files should be compiled
+        let compileFilesScope: SwiftcStepCompileFilesScope
+        /// if a module should be generated
+        let emitModule: SwiftcStepEmitModule?
+    }
+
+    /// Defines how a list of input files (*.swift) is passed to the invocation
+    public enum CompilationFilesSource {
+        /// defined in a separate file (via @/.../*.SwiftFileList)
+        case fileList(String)
+        /// explicitly passed a list of files
+        case list([String])
+    }
+
+    /// Defines how a list of output files (*.d, *.o etc.) is passed to the invocation
+    public enum CompilationFilesInputs {
+        /// defined in a separate file (via -output-file-map)
+        case fileMap(String)
+        /// defined in a separate file (via -supplementary-output-file-map)
+        case supplementaryFileMap(String)
+        /// explicitly passed in the invocation
+        case map([String: SwiftFileCompilationInfo])
+    }
+
     enum SwiftcMode: Equatable {
         case producer
         /// Commit sha of the commit to use during remote cache
@@ -28,14 +75,13 @@ public struct SwiftcContext {
         case producerFast
     }
 
-    let objcHeaderOutput: URL
+    let steps: SwiftcSteps
     let moduleName: String
-    let modulePathOutput: URL
-    /// File that defines output files locations (.d, .swiftmodule etc.)
-    let filemap: URL
+    /// A source that defines output files locations (.d, .swiftmodule etc.)
+    let inputs: CompilationFilesInputs
     let target: String
-    /// File that contains input files for the swift module compilation
-    let fileList: URL
+    /// A source that contains all input files for the swift module compilation
+    let compilationFiles: CompilationFilesSource
     let tempDir: URL
     let arch: String
     let prebuildDependenciesPath: String
@@ -43,29 +89,29 @@ public struct SwiftcContext {
     /// File that stores all compilation invocation arguments
     let invocationHistoryFile: URL
 
-
     public init(
         config: XCRemoteCacheConfig,
-        objcHeaderOutput: String,
         moduleName: String,
-        modulePathOutput: String,
-        filemap: String,
+        steps: SwiftcSteps,
+        inputs: CompilationFilesInputs,
         target: String,
-        fileList: String
+        compilationFiles: CompilationFilesSource,
+        /// any workspace file path - all other intermediate files for this compilation
+        /// are placed next to it. This path is used to infer the arch and TARGET_TEMP_DIR
+        exampleWorkspaceFilePath: String
     ) throws {
-        self.objcHeaderOutput = URL(fileURLWithPath: objcHeaderOutput)
         self.moduleName = moduleName
-        self.modulePathOutput = URL(fileURLWithPath: modulePathOutput)
-        self.filemap = URL(fileURLWithPath: filemap)
+        self.steps = steps
+        self.inputs = inputs
         self.target = target
-        self.fileList = URL(fileURLWithPath: fileList)
-        // modulePathOutput is place in $TARGET_TEMP_DIR/Objects-normal/$ARCH/$TARGET_NAME.swiftmodule
+        self.compilationFiles = compilationFiles
+        // exampleWorkspaceFilePath has a format $TARGET_TEMP_DIR/Objects-normal/$ARCH/some.file
         // That may be subject to change for other Xcode versions
-        tempDir = URL(fileURLWithPath: modulePathOutput)
+        tempDir = URL(fileURLWithPath: exampleWorkspaceFilePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .deletingLastPathComponent()
-        arch = URL(fileURLWithPath: modulePathOutput).deletingLastPathComponent().lastPathComponent
+        arch = URL(fileURLWithPath: exampleWorkspaceFilePath).deletingLastPathComponent().lastPathComponent
 
         let srcRoot: URL = URL(fileURLWithPath: config.sourceRoot)
         let remoteCommitLocation = URL(fileURLWithPath: config.remoteCommitFile, relativeTo: srcRoot)
@@ -92,14 +138,25 @@ public struct SwiftcContext {
         config: XCRemoteCacheConfig,
         input: SwiftcArgInput
     ) throws {
+        let steps = SwiftcSteps(
+            compileFilesScope: .all,
+            emitModule: SwiftcStepEmitModule(
+                objcHeaderOutput: URL(fileURLWithPath: (input.objcHeaderOutput)),
+                modulePathOutput: URL(fileURLWithPath: input.modulePathOutput),
+                // in `swiftc`, .d dependencies are pass in the output filemap
+                dependencies: nil
+            )
+        )
+        let inputs = CompilationFilesInputs.fileMap(input.filemap)
+        let compilationFiles = CompilationFilesSource.fileList(input.fileList)
         try self.init(
             config: config,
-            objcHeaderOutput: input.objcHeaderOutput,
             moduleName: input.moduleName,
-            modulePathOutput: input.modulePathOutput,
-            filemap: input.filemap,
+            steps: steps,
+            inputs: inputs,
             target: input.target,
-            fileList: input.fileList
+            compilationFiles: compilationFiles,
+            exampleWorkspaceFilePath: input.modulePathOutput
         )
     }
 }

--- a/Sources/XCRemoteCache/Commands/Swiftc/SwiftcContext.swift
+++ b/Sources/XCRemoteCache/Commands/Swiftc/SwiftcContext.swift
@@ -22,7 +22,7 @@ import Foundation
 public struct SwiftcContext {
     /// Describes the action if the module emit should happen
     /// that generates .swiftmodule and/or -Swift.h
-    public struct SwiftcStepEmitModule {
+    public struct SwiftcStepEmitModule: Equatable {
         // where the -Swift.h should be placed
         let objcHeaderOutput: URL
         // where should the .swiftmodule be placed
@@ -34,7 +34,7 @@ public struct SwiftcContext {
 
     /// Which files (from the list of all files in the module)
     /// should be compiled in this process
-    public enum SwiftcStepCompileFilesScope {
+    public enum SwiftcStepCompileFilesScope: Equatable {
         /// used if only emit module should be done
         case none
         case all
@@ -42,7 +42,7 @@ public struct SwiftcContext {
     }
 
     /// Describes which steps should be done as a part of this process
-    public struct SwiftcSteps {
+    public struct SwiftcSteps: Equatable {
         /// which files should be compiled
         let compileFilesScope: SwiftcStepCompileFilesScope
         /// if a module should be generated
@@ -50,7 +50,7 @@ public struct SwiftcContext {
     }
 
     /// Defines how a list of input files (*.swift) is passed to the invocation
-    public enum CompilationFilesSource {
+    public enum CompilationFilesSource: Equatable {
         /// defined in a separate file (via @/.../*.SwiftFileList)
         case fileList(String)
         /// explicitly passed a list of files
@@ -58,7 +58,7 @@ public struct SwiftcContext {
     }
 
     /// Defines how a list of output files (*.d, *.o etc.) is passed to the invocation
-    public enum CompilationFilesInputs {
+    public enum CompilationFilesInputs: Equatable {
         /// defined in a separate file (via -output-file-map)
         case fileMap(String)
         /// defined in a separate file (via -supplementary-output-file-map)

--- a/Sources/XCRemoteCache/Commands/Swiftc/SwiftcFilemapInputEditor.swift
+++ b/Sources/XCRemoteCache/Commands/Swiftc/SwiftcFilemapInputEditor.swift
@@ -24,7 +24,10 @@ import Yams
 enum SwiftcInputReaderError: Error {
     case readingFailed
     case invalidFormat
+    /// The file is not in the yaml format
     case invalidYamlFormat
+    /// The yaml string contains illegal characters
+    case invalidYamlString
     case missingField(String)
 }
 
@@ -98,7 +101,10 @@ class SwiftcFilemapInputEditor: SwiftcInputReader, SwiftcInputWriter {
         case .json:
             return try JSONSerialization.jsonObject(with: content, options: []) as? [String: Any]
         case .yaml:
-            return try Yams.load(yaml: String(data: content, encoding: .utf8)!) as? [String: Any]
+            guard let stringContent = String(data: content, encoding: .utf8) else {
+                throw SwiftcInputReaderError.invalidYamlString
+            }
+            return try Yams.load(yaml: stringContent) as? [String: Any]
         }
     }
 }

--- a/Sources/XCRemoteCache/Commands/Swiftc/SwiftcOrchestrator.swift
+++ b/Sources/XCRemoteCache/Commands/Swiftc/SwiftcOrchestrator.swift
@@ -27,8 +27,10 @@ class SwiftcOrchestrator {
     private let mode: SwiftcContext.SwiftcMode
     // swiftc command that should be called to generate artifacts
     private let swiftcCommand: String
-    private let objcHeaderOutput: URL
-    private let moduleOutput: URL
+    // Might be nil if invoking from frontend compilation: `swift-frontend -c`
+    private let objcHeaderOutput: URL?
+    // Might be nil if invoking from frontend compilation: `swift-frontend -c`
+    private let moduleOutput: URL?
     private let arch: String
     private let artifactBuilder: ArtifactSwiftProductsBuilder
     private let shellOut: ShellOut
@@ -39,8 +41,8 @@ class SwiftcOrchestrator {
         mode: SwiftcContext.SwiftcMode,
         swiftc: SwiftcProtocol,
         swiftcCommand: String,
-        objcHeaderOutput: URL,
-        moduleOutput: URL,
+        objcHeaderOutput: URL?,
+        moduleOutput: URL?,
         arch: String,
         artifactBuilder: ArtifactSwiftProductsBuilder,
         producerFallbackCommandProcessors: [ShellCommandsProcessor],
@@ -128,10 +130,14 @@ class SwiftcOrchestrator {
                 try processor.applyArgsRewrite(args)
             }
             try fallbackToDefaultAndWait(command: swiftcCommand, args: swiftcArgs)
-            // move generated .h to the location where artifact creator expects it
-            try artifactBuilder.includeObjCHeaderToTheArtifact(arch: arch, headerURL: objcHeaderOutput)
-            // move generated .swiftmodule to the location where artifact creator expects it
-            try artifactBuilder.includeModuleDefinitionsToTheArtifact(arch: arch, moduleURL: moduleOutput)
+            if let objcHeaderOutput = objcHeaderOutput {
+                // move generated .h to the location where artifact creator expects it
+                try artifactBuilder.includeObjCHeaderToTheArtifact(arch: arch, headerURL: objcHeaderOutput)
+            }
+            if let moduleOutput = moduleOutput {
+                // move generated .swiftmodule to the location where artifact creator expects it
+                try artifactBuilder.includeModuleDefinitionsToTheArtifact(arch: arch, moduleURL: moduleOutput)
+            }
 
             try producerFallbackCommandProcessors.forEach {
                 try $0.postCommandProcessing()

--- a/Sources/XCRemoteCache/Commands/Swiftc/XCSwiftc.swift
+++ b/Sources/XCRemoteCache/Commands/Swiftc/XCSwiftc.swift
@@ -45,15 +45,15 @@ public struct SwiftcArgInput {
     }
 }
 
-public class XCSwiftc {
-    private let command: String
-    private let inputArgs: SwiftcArgInput
+public class XCSwiftAbstract<InputArgs> {
+    let command: String
+    let inputArgs: InputArgs
     private let dependenciesWriterFactory: (URL, FileManager) -> DependenciesWriter
     private let touchFactory: (URL, FileManager) -> Touch
 
     public init(
         command: String,
-        inputArgs: SwiftcArgInput,
+        inputArgs: InputArgs,
         dependenciesWriter: @escaping (URL, FileManager) -> DependenciesWriter,
         touchFactory: @escaping (URL, FileManager) -> Touch
     ) {
@@ -63,26 +63,51 @@ public class XCSwiftc {
         self.touchFactory = touchFactory
     }
 
+    func buildContext() throws -> (XCRemoteCacheConfig, SwiftcContext) {
+        fatalError("Need to override in \(Self.self)")
+    }
+
     // swiftlint:disable:next function_body_length
-    public func run() {
+    public func run() throws {
         let fileManager = FileManager.default
-        let config: XCRemoteCacheConfig
-        let context: SwiftcContext
-        do {
-            let srcRoot: URL = URL(fileURLWithPath: fileManager.currentDirectoryPath)
-            config = try XCRemoteCacheConfigReader(srcRootPath: srcRoot.path, fileReader: fileManager)
-                .readConfiguration()
-            context = try SwiftcContext(config: config, input: inputArgs)
-        } catch {
-            exit(1, "FATAL: Swiftc initialization failed with error: \(error)")
-        }
+        let (config, context) = try buildContext()
+
         let swiftcCommand = config.swiftcCommand
         let markerURL = context.tempDir.appendingPathComponent(config.modeMarkerPath)
         let markerReader = FileMarkerReader(markerURL, fileManager: fileManager)
         let markerWriter = FileMarkerWriter(markerURL, fileAccessor: fileManager)
 
-        let inputReader = SwiftcFilemapInputEditor(context.filemap, fileManager: fileManager)
-        let fileListEditor = FileListEditor(context.fileList, fileManager: fileManager)
+        let inputReader: SwiftcInputReader
+        switch context.inputs {
+        case .fileMap(let path):
+            inputReader = SwiftcFilemapInputEditor(
+                URL(fileURLWithPath: path),
+                fileFormat: .json,
+                fileManager: fileManager
+            )
+        case .supplementaryFileMap(let path):
+            inputReader = SwiftcFilemapInputEditor(
+                URL(fileURLWithPath: path),
+                fileFormat: .yaml,
+                fileManager: fileManager
+            )
+        case .map(let map):
+            // static - passed via the arguments list
+            // TODO: check if first 2 ars can always be `nil`
+            // with Xcode 14, inputs via cmd are only used for compilations
+            inputReader = StaticSwiftcInputReader(
+                moduleDependencies: context.steps.emitModule?.dependencies,
+                swiftDependencies: nil,
+                compilationFiles: Array(map.values)
+            )
+        }
+        let fileListReader: ListReader
+        switch context.compilationFiles {
+        case .fileList(let path):
+            fileListReader = FileListEditor(URL(fileURLWithPath: path), fileManager: fileManager)
+        case .list(let paths):
+            fileListReader = StaticFileListReader(list: paths.map(URL.init(fileURLWithPath:)))
+        }
         let artifactOrganizer = ZipArtifactOrganizer(
             targetTempDir: context.tempDir,
             // xcswiftc  doesn't call artifact preprocessing
@@ -101,11 +126,16 @@ public class XCSwiftc {
             moduleName: context.moduleName,
             fileManager: fileManager
         )
-        let productsGenerator = DiskSwiftcProductsGenerator(
-            modulePathOutput: context.modulePathOutput,
-            objcHeaderOutput: context.objcHeaderOutput,
-            diskCopier: HardLinkDiskCopier(fileManager: fileManager)
-        )
+        let productsGenerator: SwiftcProductsGenerator
+        if let emitModule = context.steps.emitModule {
+            productsGenerator = DiskSwiftcProductsGenerator(
+                modulePathOutput: emitModule.modulePathOutput,
+                objcHeaderOutput: emitModule.objcHeaderOutput,
+                diskCopier: HardLinkDiskCopier(fileManager: fileManager)
+            )
+        } else {
+            productsGenerator = NoopSwiftcProductsGenerator()
+        }
         let allInvocationsStorage = ExistingFileStorage(
             storageFile: context.invocationHistoryFile,
             command: swiftcCommand
@@ -119,7 +149,7 @@ public class XCSwiftc {
         let shellOut = ProcessShellOut()
 
         let swiftc = Swiftc(
-            inputFileListReader: fileListEditor,
+            inputFileListReader: fileListReader,
             markerReader: markerReader,
             allowedFilesListScanner: allowedFilesListScanner,
             artifactOrganizer: artifactOrganizer,
@@ -136,18 +166,28 @@ public class XCSwiftc {
             mode: context.mode,
             swiftc: swiftc,
             swiftcCommand: swiftcCommand,
-            objcHeaderOutput: context.objcHeaderOutput,
-            moduleOutput: context.modulePathOutput,
+            objcHeaderOutput: context.steps.emitModule?.objcHeaderOutput,
+            moduleOutput: context.steps.emitModule?.modulePathOutput,
             arch: context.arch,
             artifactBuilder: artifactBuilder,
             producerFallbackCommandProcessors: [],
             invocationStorage: invocationStorage,
             shellOut: shellOut
         )
-        do {
-            try orchestrator.run()
-        } catch {
-            exit(1, "Swiftc failed with error: \(error)")
-        }
+        try orchestrator.run()
+    }
+}
+
+public class XCSwiftc: XCSwiftAbstract<SwiftcArgInput> {
+    override func buildContext() throws -> (XCRemoteCacheConfig, SwiftcContext) {
+        let fileReader = FileManager.default
+        let config: XCRemoteCacheConfig
+        let context: SwiftcContext
+        let srcRoot: URL = URL(fileURLWithPath: fileReader.currentDirectoryPath)
+        config = try XCRemoteCacheConfigReader(srcRootPath: srcRoot.path, fileReader: fileReader)
+            .readConfiguration()
+        context = try SwiftcContext(config: config, input: inputArgs)
+
+        return (config, context)
     }
 }

--- a/Sources/XCRemoteCache/Commands/Swiftc/XCSwiftc.swift
+++ b/Sources/XCRemoteCache/Commands/Swiftc/XCSwiftc.swift
@@ -86,6 +86,8 @@ public class XCSwiftAbstract<InputArgs> {
                 fileManager: fileManager
             )
         case .supplementaryFileMap(let path):
+            // Supplementary file map is endoded in the yaml file (contraty to
+            // the standard filemap, which is in json)
             inputReader = SwiftcFilemapInputEditor(
                 URL(fileURLWithPath: path),
                 fileFormat: .yaml,
@@ -93,10 +95,9 @@ public class XCSwiftAbstract<InputArgs> {
             )
         case .map(let map):
             // static - passed via the arguments list
-            // TODO: check if first 2 ars can always be `nil`
-            // with Xcode 14, inputs via cmd are only used for compilations
             inputReader = StaticSwiftcInputReader(
                 moduleDependencies: context.steps.emitModule?.dependencies,
+                // with Xcode 14, inputs via cmd are only used for compilations
                 swiftDependencies: nil,
                 compilationFiles: Array(map.values)
             )
@@ -134,6 +135,10 @@ public class XCSwiftAbstract<InputArgs> {
                 diskCopier: HardLinkDiskCopier(fileManager: fileManager)
             )
         } else {
+            // If the module was not requested for this proces (compiling files only)
+            // do nothing, when someone (e.g. a plugin) asks for the products generation
+            // This generation will happend in a separate process, where the module
+            // generation is requested
             productsGenerator = NoopSwiftcProductsGenerator()
         }
         let allInvocationsStorage = ExistingFileStorage(

--- a/Tests/XCRemoteCacheTests/Commands/Prepare/Integrate/XcodeProjBuildSettingsIntegrateAppenderTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/Prepare/Integrate/XcodeProjBuildSettingsIntegrateAppenderTests.swift
@@ -49,7 +49,8 @@ class XcodeProjBuildSettingsIntegrateAppenderTests: XCTestCase {
             mode: mode,
             repoRoot: rootURL,
             fakeSrcRoot: fakeRootURL,
-            sdksExclude: []
+            sdksExclude: [],
+            options: []
         )
         let result = appender.appendToBuildSettings(buildSettings: buildSettings, wrappers: binaries)
         let resultURL = try XCTUnwrap(result["XCRC_FAKE_SRCROOT"] as? String)
@@ -64,7 +65,8 @@ class XcodeProjBuildSettingsIntegrateAppenderTests: XCTestCase {
             mode: mode,
             repoRoot: rootURL,
             fakeSrcRoot: fakeRootURL,
-            sdksExclude: []
+            sdksExclude: [],
+            options: []
         )
         let result = appender.appendToBuildSettings(buildSettings: buildSettings, wrappers: binaries)
         let resultURL: String = try XCTUnwrap(result["XCRC_FAKE_SRCROOT"] as? String)
@@ -79,7 +81,8 @@ class XcodeProjBuildSettingsIntegrateAppenderTests: XCTestCase {
             mode: mode,
             repoRoot: rootURL,
             fakeSrcRoot: fakeRootURL,
-            sdksExclude: []
+            sdksExclude: [],
+            options: []
         )
         let result = appender.appendToBuildSettings(buildSettings: buildSettings, wrappers: binaries)
         let ldPlusPlus: String = try XCTUnwrap(result["LDPLUSPLUS"] as? String)
@@ -93,7 +96,8 @@ class XcodeProjBuildSettingsIntegrateAppenderTests: XCTestCase {
             mode: mode,
             repoRoot: rootURL,
             fakeSrcRoot: "/",
-            sdksExclude: ["watchOS*"]
+            sdksExclude: ["watchOS*"],
+            options: []
         )
         let result = appender.appendToBuildSettings(buildSettings: buildSettings, wrappers: binaries)
         let ldPlusPlusWatchOS: String = try XCTUnwrap(result["LDPLUSPLUS[sdk=watchOS*]"] as? String)
@@ -107,7 +111,8 @@ class XcodeProjBuildSettingsIntegrateAppenderTests: XCTestCase {
             mode: mode,
             repoRoot: rootURL,
             fakeSrcRoot: "/",
-            sdksExclude: ["watchOS*"]
+            sdksExclude: ["watchOS*"],
+            options: []
         )
         let result = appender.appendToBuildSettings(buildSettings: buildSettings, wrappers: binaries)
         let libtoolWatchOS: String = try XCTUnwrap(result["LIBTOOL[sdk=watchOS*]"] as? String)
@@ -121,7 +126,8 @@ class XcodeProjBuildSettingsIntegrateAppenderTests: XCTestCase {
             mode: mode,
             repoRoot: rootURL,
             fakeSrcRoot: "/",
-            sdksExclude: ["watchOS*", "watchsimulator*"]
+            sdksExclude: ["watchOS*", "watchsimulator*"],
+            options: []
         )
         let result = appender.appendToBuildSettings(buildSettings: buildSettings, wrappers: binaries)
         let ldPlusPlusWatchOS: String = try XCTUnwrap(result["LDPLUSPLUS[sdk=watchOS*]"] as? String)
@@ -137,7 +143,8 @@ class XcodeProjBuildSettingsIntegrateAppenderTests: XCTestCase {
             mode: mode,
             repoRoot: rootURL,
             fakeSrcRoot: "/",
-            sdksExclude: ["watchOS*", "watchsimulator*"]
+            sdksExclude: ["watchOS*", "watchsimulator*"],
+            options: []
         )
         let result = appender.appendToBuildSettings(buildSettings: buildSettings, wrappers: binaries)
         let disabledWatchOS: String = try XCTUnwrap(result["XCRC_DISABLED[sdk=watchOS*]"] as? String)
@@ -145,5 +152,35 @@ class XcodeProjBuildSettingsIntegrateAppenderTests: XCTestCase {
 
         XCTAssertEqual(disabledWatchOS, "YES")
         XCTAssertEqual(disabledWatchSimulator, "YES")
+    }
+
+    func testExcludesSwiftFrontendIntegrationForSpecificOption() throws {
+        let mode: Mode = .consumer
+        let appender = XcodeProjBuildSettingsIntegrateAppender(
+            mode: mode,
+            repoRoot: rootURL,
+            fakeSrcRoot: "/",
+            sdksExclude: [],
+            options: [.disableSwiftDriverIntegration]
+        )
+        let result = appender.appendToBuildSettings(buildSettings: buildSettings, wrappers: binaries)
+        let useSwiftIntegrationDriver: String = try XCTUnwrap(result["SWIFT_USE_INTEGRATED_DRIVER"] as? String)
+
+        XCTAssertEqual(useSwiftIntegrationDriver, "NO")
+    }
+
+    func testDoesntExcludesSwiftFrontendIntegrationForEmptyOptions() throws {
+        let mode: Mode = .consumer
+        let appender = XcodeProjBuildSettingsIntegrateAppender(
+            mode: mode,
+            repoRoot: rootURL,
+            fakeSrcRoot: "/",
+            sdksExclude: [],
+            options: []
+        )
+        let result = appender.appendToBuildSettings(buildSettings: buildSettings, wrappers: binaries)
+        let useSwiftIntegrationDriver: String? = result["SWIFT_USE_INTEGRATED_DRIVER"] as? String
+
+        XCTAssertNil(useSwiftIntegrationDriver)
     }
 }

--- a/Tests/XCRemoteCacheTests/Commands/SwiftcContextTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/SwiftcContextTests.swift
@@ -34,7 +34,7 @@ class SwiftcContextTests: FileXCTestCase {
         config = XCRemoteCacheConfig(remoteCommitFile: remoteCommitFile.path, sourceRoot: workingDir.path)
         input = SwiftcArgInput(
             objcHeaderOutput: "Target-Swift.h",
-            moduleName: "",
+            moduleName: "Target",
             modulePathOutput: modulePathOutput.path,
             filemap: "",
             target: "",

--- a/Tests/XCRemoteCacheTests/Commands/SwiftcContextTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/SwiftcContextTests.swift
@@ -25,20 +25,25 @@ class SwiftcContextTests: FileXCTestCase {
     private var config: XCRemoteCacheConfig!
     private var input: SwiftcArgInput!
     private var remoteCommitFile: URL!
+    private var modulePathOutput: URL!
+    private var fileMapUrl: URL!
+    private var fileListUrl: URL!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         let workingDir = try prepareTempDir()
         remoteCommitFile = workingDir.appendingPathComponent("arc.rc")
-        let modulePathOutput = workingDir.appendingPathComponent("mpo")
+        modulePathOutput = workingDir.appendingPathComponent("mpo")
+        fileMapUrl = workingDir.appendingPathComponent("filemap")
+        fileListUrl = workingDir.appendingPathComponent("filelist")
         config = XCRemoteCacheConfig(remoteCommitFile: remoteCommitFile.path, sourceRoot: workingDir.path)
         input = SwiftcArgInput(
             objcHeaderOutput: "Target-Swift.h",
-            moduleName: "Target",
+            moduleName: "Module",
             modulePathOutput: modulePathOutput.path,
-            filemap: "",
+            filemap: fileMapUrl.path,
             target: "",
-            fileList: ""
+            fileList: fileListUrl.path
         )
         try fileManager.write(toPath: remoteCommitFile.path, contents: "123".data(using: .utf8))
     }
@@ -76,5 +81,30 @@ class SwiftcContextTests: FileXCTestCase {
         let context = try SwiftcContext(config: config, input: input)
 
         XCTAssertEqual(context.mode, .producer)
+    }
+
+    func testStepsContainEmitingModuleAndAllCompilationScope() throws {
+        let context = try SwiftcContext(config: config, input: input)
+
+        XCTAssertEqual(context.steps, .init(
+            compileFilesScope: .all,
+            emitModule: .init(
+                objcHeaderOutput: "Target-Swift.h",
+                modulePathOutput: modulePathOutput,
+                dependencies: nil)
+            )
+        )
+    }
+
+    func testReadsInputsFromFileMap() throws {
+        let context = try SwiftcContext(config: config, input: input)
+
+        XCTAssertEqual(context.inputs, .fileMap(fileMapUrl.path))
+    }
+
+    func testReadsCompilationFilesFromFileList() throws {
+        let context = try SwiftcContext(config: config, input: input)
+
+        XCTAssertEqual(context.compilationFiles, .fileList(fileListUrl.path))
     }
 }

--- a/Tests/XCRemoteCacheTests/Commands/SwiftcOrchestratorTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/SwiftcOrchestratorTests.swift
@@ -231,4 +231,45 @@ class SwiftcOrchestratorTests: XCTestCase {
         XCTAssertEqual(artifactBuilder.addedObjCHeaders, [:])
     }
 
+
+    func testNotSetObjCHeaderIsNotCreated() throws {
+        let swiftc = SwiftcMock(mockingResult: .success)
+        let orchestrator = SwiftcOrchestrator(
+            mode: .producer,
+            swiftc: swiftc,
+            swiftcCommand: "",
+            objcHeaderOutput: nil,
+            moduleOutput: moduleOutputURL,
+            arch: "arch",
+            artifactBuilder: artifactBuilder,
+            producerFallbackCommandProcessors: [],
+            invocationStorage: invocationStorage,
+            shellOut: shellOutSpy
+        )
+
+        try orchestrator.run()
+
+        XCTAssertEqual(artifactBuilder.addedObjCHeaders, [:])
+    }
+
+    func testNotSetModuleOutputIsNotCreated() throws {
+        let swiftc = SwiftcMock(mockingResult: .success)
+        let orchestrator = SwiftcOrchestrator(
+            mode: .producer,
+            swiftc: swiftc,
+            swiftcCommand: "",
+            objcHeaderOutput: objcHeaderURL,
+            moduleOutput: nil,
+            arch: "arch",
+            artifactBuilder: artifactBuilder,
+            producerFallbackCommandProcessors: [],
+            invocationStorage: invocationStorage,
+            shellOut: shellOutSpy
+        )
+
+        try orchestrator.run()
+
+        XCTAssertEqual(artifactBuilder.addedModuleDefinitions, [:])
+    }
+
 }

--- a/Tests/XCRemoteCacheTests/Commands/SwiftcTests.swift
+++ b/Tests/XCRemoteCacheTests/Commands/SwiftcTests.swift
@@ -62,7 +62,7 @@ class SwiftcTests: FileXCTestCase {
 
         input = SwiftcArgInput(
             objcHeaderOutput: "Target-Swift.h",
-            moduleName: "",
+            moduleName: "Target",
             modulePathOutput: modulePathOutput.path,
             filemap: "",
             target: "",
@@ -276,7 +276,7 @@ class SwiftcTests: FileXCTestCase {
 
     func testCompilationUsesArchSpecificSwiftmoduleFiles() throws {
         let artifactRoot = URL(fileURLWithPath: "/cachedArtifact")
-        let artifactObjCHeader = URL(fileURLWithPath: "/cachedArtifact/include/archTest/Target-Swift.h")
+        let artifactObjCHeader = URL(fileURLWithPath: "/cachedArtifact/include/archTest/Target/Target-Swift.h")
         let artifactSwiftmodule = URL(fileURLWithPath: "/cachedArtifact/swiftmodule/archTest/Target.swiftmodule")
         let artifactSwiftdoc = URL(fileURLWithPath: "/cachedArtifact/swiftmodule/archTest/Target.swiftdoc")
         let artifactSwiftSourceInfo = URL(


### PR DESCRIPTION
As it is highly possible that Xcode 15 beta (expected on in a week, on Jun 5th) will no longer support `SWIFT_USE_INTEGRATED_DRIVER: NO`, we should be ready to add support for the integrated driver.

This is a first PR that refactors the existing implementation so it the swift-driver PR will be easier to reason about.

This PR doesn't change anything in the business logic. 

### Includes:
*  Adds a mode in the `BuildSettingsIntegrateAppender` to specify if the  `SWIFT_USE_INTEGRATED_DRIVER` should be added or not (for now, always add)
* Splits Swiftc into 2 phases: emit module and compilation. With `swiftc`, this is always done in a single process (at least from XCRemoteCache's perspective), in the driver world, that will be 2 independent processes
* Adds extra options for the input (`*.swift`) and output (*.d, *.o etc) files: either via a file (used currently) or explicitly in the cmd argument list
* `XCSwiftc`'s logic is broken down to the `XCSwiftAbstract`, which will be shared with the `XCSwiftFrontend`
* Making some params optional, which are `nil` in the swift-frontend

### Next steps
Add swift-frontend support (draft [PR](https://github.com/spotify/XCRemoteCache/pull/206))
