### PR TITLE
[SwiftDriverIntegraiton] Part IV: Add E2E tests for the swift driver integration #5

### DIFF
--- a/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
+++ b/cocoapods-plugin/lib/cocoapods-xcremotecache/gem_version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module CocoapodsXcremotecache
-  VERSION = "0.0.16"
+  VERSION = "0.0.17"
 end


### PR DESCRIPTION
The last part of the Swift integration support

* bundles `xcswift-frontent` to the .zip (incl. the `swift-frontend` -> `xcswift-frontend` and `swiftc` -> `xcswiftc` symbolic links). Symlinks are added because Xcode's driver integration requires that the `SWIFT_EXEC` has `swiftc` filename, placed next to the `swift-frontent`
* Add support of `enable_swift_driver_integration: true` in the CocoaPods plugin (the automatic integration already support that, added https://github.com/spotify/XCRemoteCache/pull/208)
* Duplicate **all** E2E tests in 2 modes: with and without `enable_swift_driver_integration`. That makes the E2E testing longer (~x2), but in the near future (when Xcode 14 support will be deprecated) we will be able to delete the legacy testing. Until we stabilize Swift Driver Integration, E2E tests will take more time. In a single CI, it seems the test pipeline takes 22min (vs 14m previously).
* For the standalone E2E tests, build&generate artifacts for the M1/M2 machines (`arm64`). As M1 machines are already more popular than Intel machines, it is better to cover that architecture in tests.
* Bumps the CocoaPods plugin, as there was a change in the implementation (0.0.17)
 
Previous PRs: https://github.com/spotify/XCRemoteCache/pull/208, https://github.com/spotify/XCRemoteCache/pull/209, https://github.com/spotify/XCRemoteCache/pull/210