### PR TITLE
Added workaround for xclibtool unexpectedly producing fat static libraries in certain cases

### DIFF
--- a/Sources/XCRemoteCache/Commands/ProductBinaryCreator/XCCreateBinary.swift
+++ b/Sources/XCRemoteCache/Commands/ProductBinaryCreator/XCCreateBinary.swift
@@ -93,7 +93,13 @@ public class XCCreateBinary {
             let cachedArtifactDir = organizer.getActiveArtifactLocation()
             let outputFilename = output.lastPathComponent
             let cachedBinaryURL = cachedArtifactDir.appendingPathComponent(outputFilename)
-            try fileManager.spt_forceLinkItem(at: cachedBinaryURL, to: output)
+            let args = ProcessInfo().arguments
+            if args[0].hasSuffix("libtool") && args[1...2] == ["-static", "-arch_only"] {
+                let arch = args[3]
+                try shellCall("lipo", args: ["-thin", arch, cachedBinaryURL.path, "-output", output.path], inDir: nil, environment: ProcessInfo.processInfo.environment)
+            } else {
+                try fileManager.spt_forceLinkItem(at: cachedBinaryURL, to: output)
+            }
             try dependenciesWriter.enable(dependencies: markerReader.listFilesURLs(), outputs: [output])
         } catch {
             errorLog("\(stepDescription) failed with error: \(error). Fallbacking to \(fallbackCommand)")


### PR DESCRIPTION
This is workaround for the case that I encounter as part of https://github.com/spotify/XCRemoteCache/issues/190#issuecomment-1659962374.

It's not exactly the fix but workaround, enforcing thinning (vs just copying cached fat binary) when xclibtool is invoked with `-static -arch xxx` arguments.