### PR TITLE
Improve XCLibtool's argument parsing

### DIFF
--- a/Sources/xclibtoolSupport/XCLibtoolHelper.swift
+++ b/Sources/xclibtoolSupport/XCLibtoolHelper.swift
@@ -47,9 +47,8 @@ public class XCLibtoolHelper {
             case "-dependency_info":
                 dependencyInfo = args[i + 1]
                 i += 1
-            case "-static":
-                () // just ignore it for now
-            case let input where ["", "a"].contains(URL(string: args[i])?.pathExtension):
+            case let input where args[i].starts(with: "/") && ["", "a"].contains(URL(string: args[i])?.pathExtension):
+                // Assume always absolute paths to the library
                 // Support for static frameworks (no extension) and static libraries (.a)
                 inputLibraries.append(input)
             default:

--- a/Tests/xclibtoolSupportTests/XCLibtoolHelperTests.swift
+++ b/Tests/xclibtoolSupportTests/XCLibtoolHelperTests.swift
@@ -23,23 +23,23 @@ import XCTest
 class XCLibtoolHelperTests: XCTestCase {
     func testStaticFrameworkUniversalBinary() throws {
         let mode = try XCLibtoolHelper.buildMode(
-            args: ["-o", "/universal/static", "/arch1/static", "arch2/static"]
+            args: ["-o", "/universal/static", "/arch1/static", "/arch2/static"]
         )
 
         XCTAssertEqual(mode, .createUniversalBinary(
             output: "/universal/static",
-            inputs: ["/arch1/static", "arch2/static"]
+            inputs: ["/arch1/static", "/arch2/static"]
         ))
     }
 
     func testStaticLibraryUniversalBinary() throws {
         let mode = try XCLibtoolHelper.buildMode(
-            args: ["-o", "/universal/static.a", "/arch1/static.a", "arch2/static.a"]
+            args: ["-o", "/universal/static.a", "/arch1/static.a", "/arch2/static.a"]
         )
 
         XCTAssertEqual(mode, .createUniversalBinary(
             output: "/universal/static.a",
-            inputs: ["/arch1/static.a", "arch2/static.a"]
+            inputs: ["/arch1/static.a", "/arch2/static.a"]
         ))
     }
 
@@ -62,5 +62,16 @@ class XCLibtoolHelperTests: XCTestCase {
                 XCTFail("Not expected error")
             }
         }
+    }
+
+    func testExplicitStaticFrameworkUniversalBinary() throws {
+        let mode = try XCLibtoolHelper.buildMode(
+            args: ["-static", "-o", "/universal/static", "/arch1/static", "/arch2/static"]
+        )
+
+        XCTAssertEqual(mode, .createUniversalBinary(
+            output: "/universal/static",
+            inputs: ["/arch1/static", "/arch2/static"]
+        ))
     }
 }


### PR DESCRIPTION
The follow-up to #221.

Previously, `XCLibtoolHelper` was eagerly treating all unknown parameters as library paths, even strings that were (very often) not valid paths. 
As Xcode always uses absolute paths when sending files paths, this PR limits pats to unknown args as paths only if those start with `/`.