### PR TITLE
Support spaces in libtools paths

### DIFF
--- a/Sources/xclibtoolSupport/XCLibtoolHelper.swift
+++ b/Sources/xclibtoolSupport/XCLibtoolHelper.swift
@@ -47,7 +47,7 @@ public class XCLibtoolHelper {
             case "-dependency_info":
                 dependencyInfo = args[i + 1]
                 i += 1
-            case let input where args[i].starts(with: "/") && ["", "a"].contains(URL(string: args[i])?.pathExtension):
+            case let input where input.starts(with: "/") && ["", "a"].contains(URL(fileURLWithPath: input).pathExtension):
                 // Assume always absolute paths to the library
                 // Support for static frameworks (no extension) and static libraries (.a)
                 inputLibraries.append(input)

--- a/Sources/xclibtoolSupport/XCLibtoolHelper.swift
+++ b/Sources/xclibtoolSupport/XCLibtoolHelper.swift
@@ -47,7 +47,8 @@ public class XCLibtoolHelper {
             case "-dependency_info":
                 dependencyInfo = args[i + 1]
                 i += 1
-            case let input where input.starts(with: "/") && ["", "a"].contains(URL(fileURLWithPath: input).pathExtension):
+            case let input where input.starts(with: "/") &&
+                ["", "a"].contains(URL(fileURLWithPath: input).pathExtension):
                 // Assume always absolute paths to the library
                 // Support for static frameworks (no extension) and static libraries (.a)
                 inputLibraries.append(input)

--- a/Tests/xclibtoolSupportTests/XCLibtoolHelperTests.swift
+++ b/Tests/xclibtoolSupportTests/XCLibtoolHelperTests.swift
@@ -74,4 +74,15 @@ class XCLibtoolHelperTests: XCTestCase {
             inputs: ["/arch1/static", "/arch2/static"]
         ))
     }
+
+    func testRecognizesPathsWithSpaces() throws {
+        let mode = try XCLibtoolHelper.buildMode(
+            args: ["-static", "-o", "/universal/static", "/arch/with space/static"]
+        )
+
+        XCTAssertEqual(mode, .createUniversalBinary(
+            output: "/universal/static",
+            inputs: ["/arch/with space/static"]
+        ))
+    }
 }


### PR DESCRIPTION
If an input path to xclibtool contains a space, previously used`URL.init(string:)` returns nil. Everywhere else we use `fileURLWithPath`, in xclibtool `.init(string:)` initializer was an oversight.

A problem reported in #190 
