### PR TITLE
Bump CI to Xcode 14.3.1/macOS14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
   macOS:
     runs-on: macos-12
     env:
-      XCODE_VERSION: ${{ '14.2' }}
+      XCODE_VERSION: ${{ '14.3' }}
     steps:
       - name: Select Xcode
         run: "sudo xcode-select -s /Applications/Xcode_$XCODE_VERSION.app"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,9 +13,9 @@ jobs:
           args: --strict
 
   macOS:
-    runs-on: macos-12
+    runs-on: macos-14
     env:
-      XCODE_VERSION: ${{ '14.3' }}
+      XCODE_VERSION: ${{ '14.3.1' }}
     steps:
       - name: Select Xcode
         run: "sudo xcode-select -s /Applications/Xcode_$XCODE_VERSION.app"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,8 @@ jobs:
         run: "sudo xcode-select -s /Applications/Xcode_$XCODE_VERSION.app"
       - name: Checkout
         uses: actions/checkout@v1
+      - name: Install nginx
+        run: brew install nginx
       - name: Build and Run
         run: rake build[release]
       - name: Test

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   docs:
-    runs-on: macos-12
+    runs-on: macos-14
     env:
-      XCODE_VERSION: ${{ '14.3' }}
+      XCODE_VERSION: ${{ '14.3.1' }}
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,7 +9,7 @@ jobs:
   docs:
     runs-on: macos-12
     env:
-      XCODE_VERSION: ${{ '14.2' }}
+      XCODE_VERSION: ${{ '14.3' }}
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Add macOS binaries to release
     runs-on: macos-12
     env:
-      XCODE_VERSION: ${{ '14.2' }}
+      XCODE_VERSION: ${{ '14.3' }}
     steps:
       - name: Select Xcode
         run: "sudo xcode-select -s /Applications/Xcode_$XCODE_VERSION.app"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,9 @@ on:
 jobs:
   macOS:
     name: Add macOS binaries to release
-    runs-on: macos-12
+    runs-on: macos-14
     env:
-      XCODE_VERSION: ${{ '14.3' }}
+      XCODE_VERSION: ${{ '14.3.1' }}
     steps:
       - name: Select Xcode
         run: "sudo xcode-select -s /Applications/Xcode_$XCODE_VERSION.app"


### PR DESCRIPTION
Bumps macOS/Xcode version to 14/14.3, as the newest Firebase SDK (used only in E2E tests) doesn't support macOS12 anymore, see https://github.com/firebase/firebase-ios-sdk/issues/12851